### PR TITLE
Enable workflow run on merge queues

### DIFF
--- a/.github/workflows/hello-world.yaml
+++ b/.github/workflows/hello-world.yaml
@@ -3,7 +3,10 @@ name: "hello world workflow"
 on:
   workflow_call:
   workflow_dispatch:
-  pull_request:
+  pull_request:    
+    branches: [ "main" ]
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   actions: read


### PR DESCRIPTION
### Ticket
No ticket

### Problem description
We want to ensure that workflow is run on attempt to merge

### What's changed
I am following these tutorials to enable automated workflow run on an attempt to merge
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions
