### PR TITLE
Add conversion for more OPs

### DIFF
--- a/.github/workflows/before_merge.yaml
+++ b/.github/workflows/before_merge.yaml
@@ -29,6 +29,18 @@ jobs:
           python3 -m pip install --upgrade pip                    
           python3 -m pip install -r requirements-dev.txt
           python3 -m pip install pytest-github-report
+      - id: dl_metal_libs
+        name: Download metal_libs
+        uses: robinraju/release-downloader@v1.10
+        with:
+          repository: tenstorrent/tt-metal
+          latest: true
+          preRelease: true
+          fileName: metal_libs-*wormhole.b0*.whl
+      - name: Install metal_libs
+        run: |
+          source venv/bin/activate
+          python3 -m pip install ${{ fromJson(steps.dl_metal_libs.outputs.downloaded_files)[0] }}
       - name: Run Tests
         env:
           pytest_verbosity: 2

--- a/.github/workflows/before_merge.yaml
+++ b/.github/workflows/before_merge.yaml
@@ -47,4 +47,4 @@ jobs:
           pytest_report_title: "⭐️ Pytest Results ⭐️"
         run: | 
           source venv/bin/activate
-          python3 -m pytest --github-report tests/*.py
+          python3 -m pytest --github-report tests/*.py -s

--- a/.github/workflows/before_merge.yaml
+++ b/.github/workflows/before_merge.yaml
@@ -15,8 +15,6 @@ jobs:
   validate-pr:
     env:
       ARCH_NAME: wormhole_b0
-      TT_METAL_HOME: ${pwd}
-      PYTHONPATH: ${pwd}
     runs-on: ["in-service", "n150"]
     steps:
       - name: Checkout Repo

--- a/.github/workflows/before_merge.yaml
+++ b/.github/workflows/before_merge.yaml
@@ -27,18 +27,6 @@ jobs:
           python3 -m pip install --upgrade pip                    
           python3 -m pip install -r requirements-dev.txt
           python3 -m pip install pytest-github-report
-      - id: dl_metal_libs
-        name: Download metal_libs
-        uses: robinraju/release-downloader@v1.10
-        with:
-          repository: tenstorrent/tt-metal
-          latest: true
-          preRelease: true
-          fileName: metal_libs-*wormhole.b0*.whl
-      - name: Install metal_libs
-        run: |
-          source venv/bin/activate
-          python3 -m pip install ${{ fromJson(steps.dl_metal_libs.outputs.downloaded_files)[0] }}
       - name: Run Tests
         env:
           pytest_verbosity: 2

--- a/README.md
+++ b/README.md
@@ -51,3 +51,11 @@ The `*_total_*_size_dist/` statistics the `op_type`'s input/output_size distribu
  - Notice: the [aten ir interface is in there](https://pytorch.org/docs/stable/torch.compiler_ir.html)
 
 [The `profile/` is the tools provided by pytorch](https://pytorch.org/tutorials/recipes/recipes/profiler_recipe.html), you can open it by the url: chrome://tracing
+
+# Run transformer models
+To run transformer model with ttnn backend, run:
+```
+PYTHONPATH=${TT_METAL_HOME}:$(pwd) python3 tools/run_transformers.py --model "phiyodr/bert-large-finetuned-squad2" --backend torch_ttnn
+```
+
+You can also substitute the backend with `torch_stat` to run a reference comparison.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
+--find-links https://download.pytorch.org/whl/torch_stable.html
+
 torch==2.2.1.0+cpu
 torchvision==0.17.1+cpu
 tabulate==0.9.0
 networkx==3.1
 graphviz
-matplotlib
+matplotlib==3.7.1
+https://github.com/tenstorrent/tt-metal/releases/download/v0.50.0-rc16/metal_libs-0.50.0rc16+wormhole.b0-cp38-cp38-linux_x86_64.whl

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ tabulate==0.9.0
 networkx==3.1
 graphviz
 matplotlib==3.7.1
-https://github.com/tenstorrent/tt-metal/releases/download/v0.50.0-rc16/metal_libs-0.50.0rc16+wormhole.b0-cp38-cp38-linux_x86_64.whl
+https://github.com/tenstorrent/tt-metal/releases/download/v0.50.0-rc18/metal_libs-0.50.0rc18+wormhole.b0-cp38-cp38-linux_x86_64.whl

--- a/tests/test_cse.py
+++ b/tests/test_cse.py
@@ -19,11 +19,11 @@ class AddModule(torch.nn.Module):
 class TestModules(unittest.TestCase):
     def setUp(self):
         # Open device 0
-        self.device: ttnn.Device = ttnn.open(0)
+        self.device: ttnn.Device = ttnn.open_device(device_id = 0)
 
     def tearDown(self):
         # Close the device
-        ttnn.close(self.device)
+        ttnn.close_device(self.device)
 
     def test_add(self):
         m = AddModule()
@@ -38,13 +38,15 @@ class TestModules(unittest.TestCase):
         option._out_fx_graphs[0].print_tabular()
         # Check the graph has be rewritten and contain ttnn ops
         nodes = list(option._out_fx_graphs[0].nodes)
-        self.assertEqual(nodes[3].target, ttnn.add)
-        self.assertEqual(nodes[3].args[0].target, ttnn.to_device)
-        self.assertEqual(nodes[3].args[0].args[0].target, ttnn.from_torch)
-        self.assertEqual(nodes[3].args[1].target, ttnn.to_device)
-        self.assertEqual(nodes[3].args[1].args[0].target, ttnn.from_torch)
-        self.assertEqual(nodes[4].target, ttnn.from_device)
-        self.assertEqual(nodes[5].target, ttnn.to_layout)
-        self.assertEqual(nodes[6].target, ttnn.to_torch)
+        self.assertEqual(nodes[4].target, ttnn.add)
+        self.assertEqual(nodes[4].args[0].target, ttnn.to_device)
+        self.assertEqual(nodes[4].args[0].args[0].target, ttnn.to_layout)
+        self.assertEqual(nodes[4].args[0].args[0].args[0].target, ttnn.from_torch)
+        self.assertEqual(nodes[4].args[1].target, ttnn.to_device)
+        self.assertEqual(nodes[4].args[1].args[0].target, ttnn.to_layout)
+        self.assertEqual(nodes[4].args[1].args[0].args[0].target, ttnn.from_torch)
+        self.assertEqual(nodes[5].target, ttnn.from_device)
+        self.assertEqual(nodes[6].target, ttnn.to_layout)
+        self.assertEqual(nodes[7].target, ttnn.to_torch)
         # Check inference result
         self.assertTrue(torch.allclose(result_before, result_after))

--- a/tests/test_cse.py
+++ b/tests/test_cse.py
@@ -19,7 +19,7 @@ class AddModule(torch.nn.Module):
 class TestModules(unittest.TestCase):
     def setUp(self):
         # Open device 0
-        self.device: ttnn.Device = ttnn.open_device(device_id = 0)
+        self.device: ttnn.Device = ttnn.open_device(device_id=0)
 
     def tearDown(self):
         # Close the device

--- a/tests/test_cse.py
+++ b/tests/test_cse.py
@@ -32,7 +32,7 @@ class TestModules(unittest.TestCase):
         result_before = m.forward(*inputs)
         option = torch_ttnn.TorchTtnnOption(device=self.device)
         # The compilation is lazy, so we need to run forward once to trigger the compilation
-        m = torch.compile(m, backend=torch_ttnn.backend(option))
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
         result_after = m.forward(*inputs)
         self.assertEqual(1, len(option._out_fx_graphs))
         option._out_fx_graphs[0].print_tabular()

--- a/tests/test_fall_back.py
+++ b/tests/test_fall_back.py
@@ -5,6 +5,7 @@ from torch_ttnn import ttnn
 
 from torch_ttnn.utils import check_with_pcc
 
+
 class MixModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -24,7 +25,7 @@ class MixModule(torch.nn.Module):
 class TestModules(unittest.TestCase):
     def setUp(self):
         # Open device 0
-        self.device: ttnn.Device = ttnn.open_device(device_id = 0)
+        self.device: ttnn.Device = ttnn.open_device(device_id=0)
 
     def tearDown(self):
         # Close the device

--- a/tests/test_fall_back.py
+++ b/tests/test_fall_back.py
@@ -3,7 +3,7 @@ import torch_ttnn
 import unittest
 from torch_ttnn import ttnn
 
-from tests.ttnn.utils_for_testing import check_with_pcc
+from torch_ttnn.utils import check_with_pcc
 
 class MixModule(torch.nn.Module):
     def __init__(self):

--- a/tests/test_fall_back.py
+++ b/tests/test_fall_back.py
@@ -3,6 +3,7 @@ import torch_ttnn
 import unittest
 from torch_ttnn import ttnn
 
+from tests.ttnn.utils_for_testing import check_with_pcc
 
 class MixModule(torch.nn.Module):
     def __init__(self):
@@ -44,13 +45,22 @@ class TestModules(unittest.TestCase):
 
         # Check the graph has be rewritten and contain ttnn ops
         nodes = list(option._out_fx_graphs[0].nodes)
-        self.assertEqual(nodes[3].target, ttnn.from_torch)
-        self.assertEqual(nodes[4].target, ttnn.to_layout)
-        self.assertEqual(nodes[5].target, ttnn.to_device)
-        self.assertEqual(nodes[6].target, ttnn.add)
-        self.assertEqual(nodes[7].target, ttnn.matmul)
-        self.assertEqual(nodes[8].target, ttnn.from_device)
-        self.assertEqual(nodes[9].target, ttnn.to_layout)
-        self.assertEqual(nodes[10].target, ttnn.to_torch)
+        self.assertEqual(nodes[2].target, ttnn.from_torch)
+        self.assertEqual(nodes[3].target, ttnn.to_layout)
+        self.assertEqual(nodes[4].target, ttnn.to_device)
+        self.assertEqual(nodes[5].target, ttnn.reciprocal)
+        self.assertEqual(nodes[6].target, ttnn.from_torch)
+        self.assertEqual(nodes[7].target, ttnn.to_layout)
+        self.assertEqual(nodes[8].target, ttnn.to_device)
+        self.assertEqual(nodes[9].target, ttnn.mul)
+        self.assertEqual(nodes[10].target, ttnn.add)
+        self.assertEqual(nodes[11].target, ttnn.matmul)
+        self.assertEqual(nodes[12].target, ttnn.reciprocal)
+        self.assertEqual(nodes[13].target, ttnn.mul)
+        self.assertEqual(nodes[14].target, ttnn.reciprocal)
+        self.assertEqual(nodes[15].target, ttnn.mul)
+        self.assertEqual(nodes[16].target, ttnn.from_device)
+        self.assertEqual(nodes[17].target, ttnn.to_layout)
+        self.assertEqual(nodes[18].target, ttnn.to_torch)
         # Check inference result
-        self.assertTrue(torch.allclose(result_before, result_after))
+        self.assertTrue(check_with_pcc(result_before, result_after))

--- a/tests/test_fall_back.py
+++ b/tests/test_fall_back.py
@@ -23,11 +23,11 @@ class MixModule(torch.nn.Module):
 class TestModules(unittest.TestCase):
     def setUp(self):
         # Open device 0
-        self.device: ttnn.Device = ttnn.open(0)
+        self.device: ttnn.Device = ttnn.open_device(device_id = 0)
 
     def tearDown(self):
         # Close the device
-        ttnn.close(self.device)
+        ttnn.close_device(self.device)
 
     def test_fall_back(self):
         m = MixModule()
@@ -45,11 +45,12 @@ class TestModules(unittest.TestCase):
         # Check the graph has be rewritten and contain ttnn ops
         nodes = list(option._out_fx_graphs[0].nodes)
         self.assertEqual(nodes[3].target, ttnn.from_torch)
-        self.assertEqual(nodes[4].target, ttnn.to_device)
-        self.assertEqual(nodes[5].target, ttnn.add)
-        self.assertEqual(nodes[6].target, ttnn.matmul)
-        self.assertEqual(nodes[7].target, ttnn.from_device)
-        self.assertEqual(nodes[8].target, ttnn.to_layout)
-        self.assertEqual(nodes[9].target, ttnn.to_torch)
+        self.assertEqual(nodes[4].target, ttnn.to_layout)
+        self.assertEqual(nodes[5].target, ttnn.to_device)
+        self.assertEqual(nodes[6].target, ttnn.add)
+        self.assertEqual(nodes[7].target, ttnn.matmul)
+        self.assertEqual(nodes[8].target, ttnn.from_device)
+        self.assertEqual(nodes[9].target, ttnn.to_layout)
+        self.assertEqual(nodes[10].target, ttnn.to_torch)
         # Check inference result
         self.assertTrue(torch.allclose(result_before, result_after))

--- a/tests/test_fall_back.py
+++ b/tests/test_fall_back.py
@@ -37,7 +37,7 @@ class TestModules(unittest.TestCase):
         option = torch_ttnn.TorchTtnnOption(device=self.device)
         option.gen_graphviz = True
         # The compilation is lazy, so we need to run forward once to trigger the compilation
-        m = torch.compile(m, backend=torch_ttnn.backend(option))
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
         result_after = m.forward(*inputs)
         self.assertEqual(1, len(option._out_fx_graphs))
         option._out_fx_graphs[0].print_tabular()

--- a/tests/test_if.py
+++ b/tests/test_if.py
@@ -36,7 +36,7 @@ class TestModules(unittest.TestCase):
         result_before_else = m.forward(*inputs_else)
         option = torch_ttnn.TorchTtnnOption(device=self.device)
         # The compilation is lazy, so we need to run forward once to trigger the compilation
-        m = torch.compile(m, backend=torch_ttnn.backend(option))
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
         result_after_then = m.forward(*inputs_then)
         result_after_else = m.forward(*inputs_else)
 

--- a/tests/test_if.py
+++ b/tests/test_if.py
@@ -22,11 +22,11 @@ class IfModule(torch.nn.Module):
 class TestModules(unittest.TestCase):
     def setUp(self):
         # Open device 0
-        self.device: ttnn.Device = ttnn.open(0)
+        self.device: ttnn.Device = ttnn.open_device(device_id = 0)
 
     def tearDown(self):
         # Close the device
-        ttnn.close(self.device)
+        ttnn.close_device(self.device)
 
     def test_if(self):
         m = IfModule()
@@ -49,21 +49,23 @@ class TestModules(unittest.TestCase):
         self.assertEqual(nodes_0[1].target, torch.ops.aten.sum.default)
         self.assertEqual(nodes_0[2].target, torch.ops.aten.gt.Scalar)
         nodes_1 = list(option._out_fx_graphs[1].nodes)
-        self.assertEqual(len(nodes_1), 8)
+        self.assertEqual(len(nodes_1), 9)
         self.assertEqual(nodes_1[1].target, ttnn.from_torch)
-        self.assertEqual(nodes_1[2].target, ttnn.to_device)
-        self.assertEqual(nodes_1[3].target, ttnn.add)
-        self.assertEqual(nodes_1[4].target, ttnn.from_device)
-        self.assertEqual(nodes_1[5].target, ttnn.to_layout)
-        self.assertEqual(nodes_1[6].target, ttnn.to_torch)
+        self.assertEqual(nodes_1[2].target, ttnn.to_layout)
+        self.assertEqual(nodes_1[3].target, ttnn.to_device)
+        self.assertEqual(nodes_1[4].target, ttnn.add)
+        self.assertEqual(nodes_1[5].target, ttnn.from_device)
+        self.assertEqual(nodes_1[6].target, ttnn.to_layout)
+        self.assertEqual(nodes_1[7].target, ttnn.to_torch)
         nodes_2 = list(option._out_fx_graphs[2].nodes)
-        self.assertEqual(len(nodes_2), 8)
+        self.assertEqual(len(nodes_2), 9)
         self.assertEqual(nodes_2[1].target, ttnn.from_torch)
-        self.assertEqual(nodes_2[2].target, ttnn.to_device)
-        self.assertEqual(nodes_2[3].target, ttnn.matmul)
-        self.assertEqual(nodes_2[4].target, ttnn.from_device)
-        self.assertEqual(nodes_2[5].target, ttnn.to_layout)
-        self.assertEqual(nodes_2[6].target, ttnn.to_torch)
+        self.assertEqual(nodes_2[2].target, ttnn.to_layout)
+        self.assertEqual(nodes_2[3].target, ttnn.to_device)
+        self.assertEqual(nodes_2[4].target, ttnn.matmul)
+        self.assertEqual(nodes_2[5].target, ttnn.from_device)
+        self.assertEqual(nodes_2[6].target, ttnn.to_layout)
+        self.assertEqual(nodes_2[7].target, ttnn.to_torch)
 
         # Check inference result
         self.assertTrue(torch.allclose(result_before_then, result_after_then))

--- a/tests/test_if.py
+++ b/tests/test_if.py
@@ -22,7 +22,7 @@ class IfModule(torch.nn.Module):
 class TestModules(unittest.TestCase):
     def setUp(self):
         # Open device 0
-        self.device: ttnn.Device = ttnn.open_device(device_id = 0)
+        self.device: ttnn.Device = ttnn.open_device(device_id=0)
 
     def tearDown(self):
         # Close the device

--- a/tests/test_more_ops.py
+++ b/tests/test_more_ops.py
@@ -4,7 +4,7 @@ import unittest
 from torch_ttnn import ttnn
 import tt_lib
 
-from tests.ttnn.utils_for_testing import check_with_pcc
+from torch_ttnn.utils import check_with_pcc
 
 class SubModule(torch.nn.Module):
     def __init__(self):

--- a/tests/test_more_ops.py
+++ b/tests/test_more_ops.py
@@ -102,7 +102,6 @@ class Reshape4DNegativeModule(torch.nn.Module):
     def output_shapes(self):
         return [(1, -1, 2, 32)]
 
-
 class PermuteModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -561,6 +560,9 @@ class TestModules(unittest.TestCase):
         # Check inference result
         self.assertTrue(torch.allclose(result_before, result_after, rtol=0.2))
 
+    @unittest.skip(
+        "NOTE(kevinwuTT) ttnn.reshape conversion needs to be reworked to support the many restrictions."
+    )
     def test_reshape(self):
         m = ReshapeModule()
         input_shapes = m.input_shapes()
@@ -582,6 +584,9 @@ class TestModules(unittest.TestCase):
         # Check inference result
         self.assertTrue(torch.allclose(result_before, result_after))
 
+    @unittest.skip(
+        "NOTE(kevinwuTT) ttnn.reshape conversion needs to be reworked to support the many restrictions."
+    )
     def test_reshape_negative(self):
         m = ReshapeNegativeModule()
         input_shapes = m.input_shapes()
@@ -603,6 +608,9 @@ class TestModules(unittest.TestCase):
         # Check inference result
         self.assertTrue(torch.allclose(result_before, result_after))
 
+    @unittest.skip(
+        "NOTE(kevinwuTT) ttnn.reshape conversion needs to be reworked to support the many restrictions."
+    )
     def test_reshape_4d(self):
         m = Reshape4DModule()
         input_shapes = m.input_shapes()
@@ -627,6 +635,9 @@ class TestModules(unittest.TestCase):
         # Check inference result
         self.assertTrue(torch.allclose(result_before, result_after))
 
+    @unittest.skip(
+        "NOTE(kevinwuTT) ttnn.reshape conversion needs to be reworked to support the many restrictions."
+    )
     def test_reshape_4d_negative(self):
         m = Reshape4DNegativeModule()
         input_shapes = m.input_shapes()
@@ -813,6 +824,9 @@ class TestModules(unittest.TestCase):
         # Check inference result
         self.assertTrue(torch.allclose(result_before, result_after))
 
+    @unittest.skip(
+        "NOTE(kevinwuTT) Re-enable after conversion to ttnn.embedding with both ROW_MAJOR_LAYOUT and TILE_LAYOUT"
+    )
     def test_embedding(self):
         m = EmbeddingModule()
         input_shapes = m.input_shapes()

--- a/tests/test_more_ops.py
+++ b/tests/test_more_ops.py
@@ -441,6 +441,16 @@ class CosModule(torch.nn.Module):
     def input_shapes(self):
         return [(4, 4)]
 
+class SigmoidModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        return torch.sigmoid(x)
+
+    def input_shapes(self):
+        return [(4, 4)]
+
 class TestModules(unittest.TestCase):
     def setUp(self):
         # Open device 0
@@ -1535,6 +1545,30 @@ class TestModules(unittest.TestCase):
         # Check the graph has be rewritten and contain ttnn ops
         nodes = list(option._out_fx_graphs[0].nodes)
         self.assertTrue(nodes[4].target == ttnn.cos)
+        self.assertTrue(nodes[4].args[0].target == ttnn.to_device)
+        self.assertTrue(nodes[4].args[0].args[0].target == ttnn.to_layout)
+        self.assertTrue(nodes[4].args[0].args[0].args[0].target == ttnn.from_torch)
+        self.assertTrue(nodes[5].target == ttnn.from_device)
+        self.assertTrue(nodes[6].target == ttnn.to_layout)
+        self.assertTrue(nodes[7].target == ttnn.to_torch)
+        # Check inference result
+        self.assertTrue(torch.allclose(result_before, result_after, rtol=0.2))
+
+    def test_sigmoid(self):
+        m = SigmoidModule()
+        input_shapes = m.input_shapes()
+        inputs = [torch.rand(shape, dtype=torch.bfloat16) for shape in input_shapes]
+        result_before = m.forward(*inputs)
+        option = torch_ttnn.TorchTtnnOption(device=self.device)
+        option.gen_graphviz = True
+        # The compilation is lazy, so we need to run forward once to trigger the compilation
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+        result_after = m.forward(*inputs)
+        option._out_fx_graphs[0].print_tabular()
+
+        # Check the graph has be rewritten and contain ttnn ops
+        nodes = list(option._out_fx_graphs[0].nodes)
+        self.assertTrue(nodes[4].target == ttnn.sigmoid)
         self.assertTrue(nodes[4].args[0].target == ttnn.to_device)
         self.assertTrue(nodes[4].args[0].args[0].target == ttnn.to_layout)
         self.assertTrue(nodes[4].args[0].args[0].args[0].target == ttnn.from_torch)

--- a/tests/test_more_ops.py
+++ b/tests/test_more_ops.py
@@ -714,6 +714,9 @@ class TestModules(unittest.TestCase):
         # Check inference result
         self.assertTrue(torch.allclose(result_before, result_after))
 
+    @unittest.skip(
+        "NOTE(kevinwuTT) ttnn.split is "#8364 ttnn.split has been using fallback version and is not implemented yet"
+    )
     def test_split(self):
         m = SplitModule()
         input_shapes = m.input_shapes()

--- a/tests/test_more_ops.py
+++ b/tests/test_more_ops.py
@@ -3,6 +3,7 @@ import torch_ttnn
 import unittest
 from torch_ttnn import ttnn
 
+from tests.ttnn.utils_for_testing import check_with_pcc
 
 class SubModule(torch.nn.Module):
     def __init__(self):
@@ -80,6 +81,25 @@ class PermuteModule(torch.nn.Module):
     def input_shapes(self):
         return [(4, 4)]
 
+class ReluModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        return torch.relu(x)
+
+    def input_shapes(self):
+        return [(4, 4)]
+
+class AddMmModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input, mat1, mat2):
+        return torch.addmm(input, mat1, mat2)
+
+    def input_shapes(self):
+        return [(4, 4), (4, 4), (4, 4)]
 
 class TestModules(unittest.TestCase):
     def setUp(self):
@@ -262,6 +282,61 @@ class TestModules(unittest.TestCase):
         # Check inference result
         self.assertTrue(torch.allclose(result_before, result_after))
 
+    def test_relu(self):
+        m = ReluModule()
+        input_shapes = m.input_shapes()
+        inputs = [torch.rand(shape, dtype=torch.bfloat16) for shape in input_shapes]
+        result_before = m.forward(*inputs)
+        option = torch_ttnn.TorchTtnnOption(device=self.device)
+        option.gen_graphviz = True
+        # The compilation is lazy, so we need to run forward once to trigger the compilation
+        m = torch.compile(m, backend=torch_ttnn.backend(option))
+        result_after = m.forward(*inputs)
+        option._out_fx_graphs[0].print_tabular()
+
+        # Check the graph has be rewritten and contain ttnn ops
+        nodes = list(option._out_fx_graphs[0].nodes)
+        self.assertTrue(nodes[4].target == ttnn.relu)
+        self.assertTrue(nodes[4].args[0].target == ttnn.to_device)
+        self.assertTrue(nodes[4].args[0].args[0].target == ttnn.to_layout)
+        self.assertTrue(nodes[4].args[0].args[0].args[0].target == ttnn.from_torch)
+        self.assertTrue(nodes[5].target == ttnn.from_device)
+        self.assertTrue(nodes[6].target == ttnn.to_layout)
+        self.assertTrue(nodes[7].target == ttnn.to_torch)
+        # Check inference result
+        self.assertTrue(torch.allclose(result_before, result_after))
+
+    def test_addmm(self):
+        m = AddMmModule()
+        input_shapes = m.input_shapes()
+        inputs = [torch.rand(shape, dtype=torch.bfloat16) for shape in input_shapes]
+        result_before = m.forward(*inputs)
+        option = torch_ttnn.TorchTtnnOption(device=self.device)
+        option.gen_graphviz = True
+        # The compilation is lazy, so we need to run forward once to trigger the compilation
+        m = torch.compile(m, backend=torch_ttnn.backend(option))
+        result_after = m.forward(*inputs)
+        option._out_fx_graphs[0].print_tabular()
+
+        # Check the graph has be rewritten and contain ttnn ops
+        nodes = list(option._out_fx_graphs[0].nodes)
+        self.assertTrue(nodes[9].target == ttnn.matmul)
+        self.assertTrue(nodes[9].args[0].target == ttnn.to_device)
+        self.assertTrue(nodes[9].args[0].args[0].target == ttnn.to_layout)
+        self.assertTrue(nodes[9].args[0].args[0].args[0].target == ttnn.from_torch)
+        self.assertTrue(nodes[9].args[1].target == ttnn.to_device)
+        self.assertTrue(nodes[9].args[1].args[0].target == ttnn.to_layout)
+        self.assertTrue(nodes[9].args[1].args[0].args[0].target == ttnn.from_torch)
+        self.assertTrue(nodes[13].target == ttnn.add)
+        self.assertTrue(nodes[13].args[0].target == ttnn.to_device)
+        self.assertTrue(nodes[13].args[0].args[0].target == ttnn.to_layout)
+        self.assertTrue(nodes[13].args[0].args[0].args[0].target == ttnn.from_torch)
+        self.assertTrue(nodes[13].args[1].target == ttnn.matmul)
+        self.assertTrue(nodes[14].target == ttnn.from_device)
+        self.assertTrue(nodes[15].target == ttnn.to_layout)
+        self.assertTrue(nodes[16].target == ttnn.to_torch)
+        # Check inference result
+        self.assertTrue(check_with_pcc(result_before, result_after))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_more_ops.py
+++ b/tests/test_more_ops.py
@@ -2,6 +2,7 @@ import torch
 import torch_ttnn
 import unittest
 from torch_ttnn import ttnn
+import tt_lib
 
 from tests.ttnn.utils_for_testing import check_with_pcc
 
@@ -185,10 +186,42 @@ class LayerNormModule(torch.nn.Module):
         # [embedding, weight, bias]
         return [(batch, sentence_length, embedding_dim), (embedding_dim), (embedding_dim)]
 
+class NegModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input):
+        return torch.neg(input)
+
+    def input_shapes(self):
+        return[(4)]
+
+class OnesModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, shape):
+        return torch.ones(shape)
+
+    def input_shapes(self):
+        return[(32, 32)]
+
+class TrilModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input):
+        return torch.tril(input)
+
+    def input_shapes(self):
+        return[(4, 4)]
+
 class TestModules(unittest.TestCase):
     def setUp(self):
         # Open device 0
         self.device: ttnn.Device = ttnn.open_device(device_id = 0)
+        # For AutoFormat
+        tt_lib.device.SetDefaultDevice(self.device)
 
     def tearDown(self):
         # Close the device
@@ -632,6 +665,75 @@ class TestModules(unittest.TestCase):
         self.assertTrue(nodes[15].target == ttnn.to_torch)
         # Check inference result
         self.assertTrue(check_with_pcc(result_before, result_after, 0.9998))
+
+    def test_neg(self):
+        m = NegModule()
+        input_shapes = m.input_shapes()
+        inputs = [torch.rand(shape, dtype=torch.bfloat16) for shape in input_shapes]
+        result_before = m.forward(*inputs)
+        option = torch_ttnn.TorchTtnnOption(device=self.device)
+        option.gen_graphviz = True
+        # The compilation is lazy, so we need to run forward once to trigger the compilation
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+        result_after = m.forward(*inputs)
+        option._out_fx_graphs[0].print_tabular()
+
+        # Check the graph has be rewritten and contain ttnn ops
+        nodes = list(option._out_fx_graphs[0].nodes)
+        self.assertTrue(nodes[4].target == ttnn.neg)
+        self.assertTrue(nodes[4].args[0].target == ttnn.to_device)
+        self.assertTrue(nodes[4].args[0].args[0].target == ttnn.to_layout)
+        self.assertTrue(nodes[4].args[0].args[0].args[0].target == ttnn.from_torch)
+        self.assertTrue(nodes[5].target == ttnn.from_device)
+        self.assertTrue(nodes[6].target == ttnn.to_layout)
+        self.assertTrue(nodes[7].target == ttnn.to_torch)
+        # Check inference result
+        self.assertTrue(torch.allclose(result_before, result_after))
+
+    def test_ones(self):
+        m = OnesModule()
+        input_shapes = m.input_shapes()[0]
+        result_before = m.forward(input_shapes)
+        result_before = result_before.to(torch.bfloat16)
+        option = torch_ttnn.TorchTtnnOption(device=self.device)
+        option.gen_graphviz = True
+        # The compilation is lazy, so we need to run forward once to trigger the compilation
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+        result_after = m.forward(input_shapes)
+        option._out_fx_graphs[0].print_tabular()
+
+        # Check the graph has be rewritten and contain ttnn ops
+        nodes = list(option._out_fx_graphs[0].nodes)
+        self.assertTrue(nodes[0].target == ttnn.ones)
+        self.assertTrue(nodes[1].target == ttnn.from_device)
+        self.assertTrue(nodes[2].target == ttnn.to_layout)
+        self.assertTrue(nodes[3].target == ttnn.to_torch)
+        # Check inference result
+        self.assertTrue(torch.allclose(result_before, result_after))
+
+    def test_tril(self):
+        m = TrilModule()
+        input_shapes = m.input_shapes()
+        inputs = [torch.rand(shape, dtype=torch.bfloat16) for shape in input_shapes]
+        result_before = m.forward(*inputs)
+        option = torch_ttnn.TorchTtnnOption(device=self.device)
+        option.gen_graphviz = True
+        # The compilation is lazy, so we need to run forward once to trigger the compilation
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+        result_after = m.forward(*inputs)
+        option._out_fx_graphs[0].print_tabular()
+
+        # Check the graph has be rewritten and contain ttnn ops
+        nodes = list(option._out_fx_graphs[0].nodes)
+        self.assertTrue(nodes[4].target == ttnn.tril)
+        self.assertTrue(nodes[4].args[0].target == ttnn.to_device)
+        self.assertTrue(nodes[4].args[0].args[0].target == ttnn.to_layout)
+        self.assertTrue(nodes[4].args[0].args[0].args[0].target == ttnn.from_torch)
+        self.assertTrue(nodes[5].target == ttnn.from_device)
+        self.assertTrue(nodes[6].target == ttnn.to_layout)
+        self.assertTrue(nodes[7].target == ttnn.to_torch)
+        # Check inference result
+        self.assertTrue(torch.allclose(result_before, result_after))
 
 
 if __name__ == "__main__":

--- a/tests/test_more_ops.py
+++ b/tests/test_more_ops.py
@@ -174,16 +174,6 @@ class EmbeddingModule(torch.nn.Module):
     def input_shapes(self):
         return [((1, 2, 4, 5), (4, 3, 2, 9)), (10, 4)]
 
-class SplitModule(torch.nn.Module):
-    def __init__(self):
-        super().__init__()
-
-    def forward(self, input, split_size, dim):
-        return torch.split(input, split_size, dim)
-
-    def input_shapes(self):
-        return [(2, 4)]
-
 class CloneFromNodeModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -837,39 +827,6 @@ class TestModules(unittest.TestCase):
         self.assertTrue(nodes[8].target == ttnn.to_torch)
         # Check inference result
         self.assertTrue(torch.allclose(result_before, result_after))
-
-    @unittest.skip(
-        "NOTE(kevinwuTT) ttnn.split is "#8364 ttnn.split has been using fallback version and is not implemented yet"
-    )
-    def test_split(self):
-        m = SplitModule()
-        input_shapes = m.input_shapes()
-        inputs = [torch.rand(shape, dtype=torch.bfloat16) for shape in input_shapes]
-        # TODO(kevinwuTT): test other shapes and dims
-        result_before = m.forward(*inputs, 2, -1)
-        option = torch_ttnn.TorchTtnnOption(device=self.device)
-        option.gen_graphviz = True
-        # The compilation is lazy, so we need to run forward once to trigger the compilation
-        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
-        result_after = m.forward(*inputs, 2, -1)
-        option._out_fx_graphs[0].print_tabular()
-
-        # Check the graph has be rewritten and contain ttnn ops
-        nodes = list(option._out_fx_graphs[0].nodes)
-        self.assertTrue(nodes[4].target == ttnn.split)
-        self.assertTrue(nodes[4].args[0].target == ttnn.to_device)
-        self.assertTrue(nodes[4].args[0].args[0].target == ttnn.to_layout)
-        self.assertTrue(nodes[4].args[0].args[0].args[0].target == ttnn.from_torch)
-        self.assertTrue(nodes[7].target == ttnn.to_layout)
-        self.assertTrue(nodes[8].target == ttnn.from_device)
-        self.assertTrue(nodes[9].target == ttnn.to_torch)
-        self.assertTrue(nodes[10].target == ttnn.to_layout)
-        self.assertTrue(nodes[11].target == ttnn.from_device)
-        self.assertTrue(nodes[12].target == ttnn.to_torch)
-        # Check inference result
-        self.assertTrue(len(result_before) == len(result_after))
-        for before, after in zip(result_before, result_after):
-            self.assertTrue(torch.allclose(before, after))
 
     def test_clone_from_arg(self):
         m = CloneFromArgModule()

--- a/tests/test_more_ops.py
+++ b/tests/test_more_ops.py
@@ -73,11 +73,11 @@ class PermuteModule(torch.nn.Module):
 class TestModules(unittest.TestCase):
     def setUp(self):
         # Open device 0
-        self.device: ttnn.Device = ttnn.open(0)
+        self.device: ttnn.Device = ttnn.open_device(device_id = 0)
 
     def tearDown(self):
         # Close the device
-        ttnn.close(self.device)
+        ttnn.close_device(self.device)
 
     def test_sub(self):
         m = SubModule()
@@ -93,12 +93,13 @@ class TestModules(unittest.TestCase):
 
         # Check the graph has be rewritten and contain ttnn ops
         nodes = list(option._out_fx_graphs[0].nodes)
-        self.assertTrue(nodes[6].target == ttnn.sub)
-        self.assertTrue(nodes[6].args[0].target == ttnn.to_device)
-        self.assertTrue(nodes[6].args[0].args[0].target == ttnn.from_torch)
-        self.assertTrue(nodes[7].target == ttnn.from_device)
-        self.assertTrue(nodes[8].target == ttnn.to_layout)
-        self.assertTrue(nodes[9].target == ttnn.to_torch)
+        self.assertTrue(nodes[8].target == ttnn.sub)
+        self.assertTrue(nodes[8].args[0].target == ttnn.to_device)
+        self.assertTrue(nodes[8].args[0].args[0].target == ttnn.to_layout)
+        self.assertTrue(nodes[8].args[0].args[0].args[0].target == ttnn.from_torch)
+        self.assertTrue(nodes[9].target == ttnn.from_device)
+        self.assertTrue(nodes[10].target == ttnn.to_layout)
+        self.assertTrue(nodes[11].target == ttnn.to_torch)
         # Check inference result
         self.assertTrue(torch.allclose(result_before, result_after))
 
@@ -118,12 +119,13 @@ class TestModules(unittest.TestCase):
 
         # Check the graph has be rewritten and contain ttnn ops
         nodes = list(option._out_fx_graphs[0].nodes)
-        self.assertTrue(nodes[6].target == ttnn.mul)
-        self.assertTrue(nodes[6].args[0].target == ttnn.to_device)
-        self.assertTrue(nodes[6].args[0].args[0].target == ttnn.from_torch)
-        self.assertTrue(nodes[7].target == ttnn.from_device)
-        self.assertTrue(nodes[8].target == ttnn.to_layout)
-        self.assertTrue(nodes[9].target == ttnn.to_torch)
+        self.assertTrue(nodes[8].target == ttnn.mul)
+        self.assertTrue(nodes[8].args[0].target == ttnn.to_device)
+        self.assertTrue(nodes[8].args[0].args[0].target == ttnn.to_layout)
+        self.assertTrue(nodes[8].args[0].args[0].args[0].target == ttnn.from_torch)
+        self.assertTrue(nodes[9].target == ttnn.from_device)
+        self.assertTrue(nodes[10].target == ttnn.to_layout)
+        self.assertTrue(nodes[11].target == ttnn.to_torch)
         # Check inference result
         self.assertTrue(torch.allclose(result_before, result_after))
 
@@ -142,12 +144,13 @@ class TestModules(unittest.TestCase):
 
         # Check the graph has be rewritten and contain ttnn ops
         nodes = list(option._out_fx_graphs[0].nodes)
-        self.assertTrue(nodes[3].target == ttnn.softmax)
-        self.assertTrue(nodes[3].args[0].target == ttnn.to_device)
-        self.assertTrue(nodes[3].args[0].args[0].target == ttnn.from_torch)
-        self.assertTrue(nodes[4].target == ttnn.from_device)
-        self.assertTrue(nodes[5].target == ttnn.to_layout)
-        self.assertTrue(nodes[6].target == ttnn.to_torch)
+        self.assertTrue(nodes[4].target == ttnn.softmax)
+        self.assertTrue(nodes[4].args[0].target == ttnn.to_device)
+        self.assertTrue(nodes[4].args[0].args[0].target == ttnn.to_layout)
+        self.assertTrue(nodes[4].args[0].args[0].args[0].target == ttnn.from_torch)
+        self.assertTrue(nodes[5].target == ttnn.from_device)
+        self.assertTrue(nodes[6].target == ttnn.to_layout)
+        self.assertTrue(nodes[7].target == ttnn.to_torch)
         # Check inference result
         self.assertTrue(torch.allclose(result_before, result_after, rtol=0.2))
 
@@ -165,12 +168,13 @@ class TestModules(unittest.TestCase):
 
         # Check the graph has be rewritten and contain ttnn ops
         nodes = list(option._out_fx_graphs[0].nodes)
-        self.assertTrue(nodes[3].target == ttnn.tanh)
-        self.assertTrue(nodes[3].args[0].target == ttnn.to_device)
-        self.assertTrue(nodes[3].args[0].args[0].target == ttnn.from_torch)
-        self.assertTrue(nodes[4].target == ttnn.from_device)
-        self.assertTrue(nodes[5].target == ttnn.to_layout)
-        self.assertTrue(nodes[6].target == ttnn.to_torch)
+        self.assertTrue(nodes[4].target == ttnn.tanh)
+        self.assertTrue(nodes[4].args[0].target == ttnn.to_device)
+        self.assertTrue(nodes[4].args[0].args[0].target == ttnn.to_layout)
+        self.assertTrue(nodes[4].args[0].args[0].args[0].target == ttnn.from_torch)
+        self.assertTrue(nodes[5].target == ttnn.from_device)
+        self.assertTrue(nodes[6].target == ttnn.to_layout)
+        self.assertTrue(nodes[7].target == ttnn.to_torch)
         # Check inference result
         self.assertTrue(torch.allclose(result_before, result_after, rtol=0.2))
 
@@ -198,9 +202,9 @@ class TestModules(unittest.TestCase):
         # Check inference result
         self.assertTrue(torch.allclose(result_before, result_after))
 
-    # NOTE(yoco) This test failed because currently
-    # the ttnn.permute does nothing. Seems like the ttnn.permute
-    # is not implemented yet.
+    @unittest.skip(
+        "NOTE(yoco) This test failed because currently the ttnn.permute does nothing. Seems like the ttnn.permute is not implemented yet."
+    )
     def test_permute(self):
         m = PermuteModule()
         input_shapes = m.input_shapes()
@@ -216,12 +220,13 @@ class TestModules(unittest.TestCase):
 
         # Check the graph has be rewritten and contain ttnn ops
         nodes = list(option._out_fx_graphs[0].nodes)
-        self.assertTrue(nodes[3].target == ttnn.permute)
-        self.assertTrue(nodes[3].args[0].target == ttnn.to_device)
-        self.assertTrue(nodes[3].args[0].args[0].target == ttnn.from_torch)
-        self.assertTrue(nodes[4].target == ttnn.from_device)
-        self.assertTrue(nodes[5].target == ttnn.to_layout)
-        self.assertTrue(nodes[6].target == ttnn.to_torch)
+        self.assertTrue(nodes[4].target == ttnn.permute)
+        self.assertTrue(nodes[4].args[0].target == ttnn.to_device)
+        self.assertTrue(nodes[4].args[0].args[0].target == ttnn.to_layout)
+        self.assertTrue(nodes[4].args[0].args[0].args[0].target == ttnn.from_torch)
+        self.assertTrue(nodes[5].target == ttnn.from_device)
+        self.assertTrue(nodes[6].target == ttnn.to_layout)
+        self.assertTrue(nodes[7].target == ttnn.to_torch)
         # Check inference result
         self.assertTrue(torch.allclose(result_before, result_after))
 

--- a/tests/test_more_ops.py
+++ b/tests/test_more_ops.py
@@ -294,6 +294,68 @@ class MeanDimModule(torch.nn.Module):
     def input_shapes(self):
         return[(1, 32, 32), -1]
 
+class PowTensorScalarModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input):
+        # torch.fx lowers this into aten.pow.Tensor_Scalar
+        square = torch.square(input)
+        return square
+
+    def input_shapes(self):
+        return[(4, 4)]
+
+class RsqrtModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input):
+        return torch.rsqrt(input)
+
+    def input_shapes(self):
+        return[(4, 4)]
+
+class SiluModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input):
+        return torch.nn.functional.silu(input)
+
+    def input_shapes(self):
+        return[(4, 4)]
+
+class AdaptiveAvgPool2dModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input):
+        return torch._adaptive_avg_pool2d(input, (1, 1))
+
+    def input_shapes(self):
+        return[(1, 2048, 7, 7)]
+
+class ClampModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input, min, max):
+        return torch.clamp(input, min=min, max=max)
+
+    def input_shapes(self):
+        return[(4, 4)]
+
+class SqueezeDimModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input, dim):
+        return torch.squeeze(input, dim)
+
+    def input_shapes(self):
+        return[(1, 32, 16)]
+
 class TestModules(unittest.TestCase):
     def setUp(self):
         # Open device 0
@@ -1003,6 +1065,151 @@ class TestModules(unittest.TestCase):
         # Check inference result
         self.assertTrue(check_with_pcc(result_before, result_after))
 
+    def test_pow_tensor_scalar(self):
+        m = PowTensorScalarModule()
+        input_shapes = m.input_shapes()
+        inputs = [torch.rand(shape, dtype=torch.bfloat16) for shape in input_shapes]
+        result_before = m.forward(*inputs)
+        option = torch_ttnn.TorchTtnnOption(device=self.device)
+        option.gen_graphviz = True
+        # The compilation is lazy, so we need to run forward once to trigger the compilation
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+        result_after = m.forward(*inputs)
+        option._out_fx_graphs[0].print_tabular()
+
+        # Check the graph has be rewritten and contain ttnn ops
+        nodes = list(option._out_fx_graphs[0].nodes)
+        self.assertTrue(nodes[4].target == ttnn.pow)
+        self.assertTrue(nodes[4].args[0].target == ttnn.to_device)
+        self.assertTrue(nodes[4].args[0].args[0].target == ttnn.to_layout)
+        self.assertTrue(nodes[4].args[0].args[0].args[0].target == ttnn.from_torch)
+        self.assertTrue(nodes[5].target == ttnn.from_device)
+        self.assertTrue(nodes[6].target == ttnn.to_layout)
+        self.assertTrue(nodes[7].target == ttnn.to_torch)
+        # Check inference result
+        self.assertTrue(check_with_pcc(result_before, result_after))
+
+    def test_rsqrt(self):
+        m = RsqrtModule()
+        input_shapes = m.input_shapes()
+        inputs = [torch.rand(shape, dtype=torch.bfloat16) for shape in input_shapes]
+        result_before = m.forward(*inputs)
+        option = torch_ttnn.TorchTtnnOption(device=self.device)
+        option.gen_graphviz = True
+        # The compilation is lazy, so we need to run forward once to trigger the compilation
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+        result_after = m.forward(*inputs)
+        option._out_fx_graphs[0].print_tabular()
+
+        # Check the graph has be rewritten and contain ttnn ops
+        nodes = list(option._out_fx_graphs[0].nodes)
+        self.assertTrue(nodes[4].target == ttnn.rsqrt)
+        self.assertTrue(nodes[4].args[0].target == ttnn.to_device)
+        self.assertTrue(nodes[4].args[0].args[0].target == ttnn.to_layout)
+        self.assertTrue(nodes[4].args[0].args[0].args[0].target == ttnn.from_torch)
+        self.assertTrue(nodes[5].target == ttnn.from_device)
+        self.assertTrue(nodes[6].target == ttnn.to_layout)
+        self.assertTrue(nodes[7].target == ttnn.to_torch)
+        # Check inference result
+        self.assertTrue(check_with_pcc(result_before, result_after))
+
+    def test_silu(self):
+        m = SiluModule()
+        input_shapes = m.input_shapes()
+        inputs = [torch.rand(shape, dtype=torch.bfloat16) for shape in input_shapes]
+        result_before = m.forward(*inputs)
+        option = torch_ttnn.TorchTtnnOption(device=self.device)
+        option.gen_graphviz = True
+        # The compilation is lazy, so we need to run forward once to trigger the compilation
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+        result_after = m.forward(*inputs)
+        option._out_fx_graphs[0].print_tabular()
+
+        # Check the graph has be rewritten and contain ttnn ops
+        nodes = list(option._out_fx_graphs[0].nodes)
+        self.assertTrue(nodes[4].target == ttnn.silu)
+        self.assertTrue(nodes[4].args[0].target == ttnn.to_device)
+        self.assertTrue(nodes[4].args[0].args[0].target == ttnn.to_layout)
+        self.assertTrue(nodes[4].args[0].args[0].args[0].target == ttnn.from_torch)
+        self.assertTrue(nodes[5].target == ttnn.from_device)
+        self.assertTrue(nodes[6].target == ttnn.to_layout)
+        self.assertTrue(nodes[7].target == ttnn.to_torch)
+        # Check inference result
+        self.assertTrue(check_with_pcc(result_before, result_after))
+
+    def test_adaptive_avg_pool_2d(self):
+        m = AdaptiveAvgPool2dModule()
+        input_shapes = m.input_shapes()
+        inputs = [torch.rand(shape, dtype=torch.bfloat16) for shape in input_shapes]
+        result_before = m.forward(*inputs)
+        option = torch_ttnn.TorchTtnnOption(device=self.device)
+        option.gen_graphviz = True
+        # The compilation is lazy, so we need to run forward once to trigger the compilation
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+        result_after = m.forward(*inputs)
+        option._out_fx_graphs[0].print_tabular()
+
+        # Check the graph has be rewritten and contain ttnn ops
+        nodes = list(option._out_fx_graphs[0].nodes)
+        self.assertTrue(nodes[4].target == ttnn.global_avg_pool2d)
+        self.assertTrue(nodes[4].args[0].target == ttnn.to_device)
+        self.assertTrue(nodes[4].args[0].args[0].target == ttnn.to_layout)
+        self.assertTrue(nodes[4].args[0].args[0].args[0].target == ttnn.from_torch)
+        self.assertTrue(nodes[5].target == ttnn.from_device)
+        self.assertTrue(nodes[6].target == ttnn.to_layout)
+        self.assertTrue(nodes[7].target == ttnn.to_torch)
+        # Check inference result
+        self.assertTrue(check_with_pcc(result_before, result_after))
+
+    def test_clamp(self):
+        m = ClampModule()
+        input_shapes = m.input_shapes()
+        inputs = [torch.rand(shape, dtype=torch.bfloat16) for shape in input_shapes]
+        min, max = -0.5, 0.5
+        result_before = m.forward(inputs[0], min, max)
+        option = torch_ttnn.TorchTtnnOption(device=self.device)
+        option.gen_graphviz = True
+        # The compilation is lazy, so we need to run forward once to trigger the compilation
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+        result_after = m.forward(inputs[0], min, max)
+        option._out_fx_graphs[0].print_tabular()
+
+        # Check the graph has be rewritten and contain ttnn ops
+        nodes = list(option._out_fx_graphs[0].nodes)
+        self.assertTrue(nodes[4].target == ttnn.clip)
+        self.assertTrue(nodes[4].args[0].target == ttnn.to_device)
+        self.assertTrue(nodes[4].args[0].args[0].target == ttnn.to_layout)
+        self.assertTrue(nodes[4].args[0].args[0].args[0].target == ttnn.from_torch)
+        self.assertTrue(nodes[5].target == ttnn.from_device)
+        self.assertTrue(nodes[6].target == ttnn.to_layout)
+        self.assertTrue(nodes[7].target == ttnn.to_torch)
+        # Check inference result
+        self.assertTrue(check_with_pcc(result_before, result_after))
+
+    def test_squeeze_dim(self):
+        m = SqueezeDimModule()
+        input_shapes = m.input_shapes()
+        inputs = [torch.zeros(shape, dtype=torch.bfloat16) for shape in input_shapes]
+        dim = 0
+        result_before = m.forward(inputs[0], dim)
+        option = torch_ttnn.TorchTtnnOption(device=self.device)
+        option.gen_graphviz = True
+        # The compilation is lazy, so we need to run forward once to trigger the compilation
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+        result_after = m.forward(inputs[0], dim)
+        option._out_fx_graphs[0].print_tabular()
+
+        # Check the graph has be rewritten and contain ttnn ops
+        nodes = list(option._out_fx_graphs[0].nodes)
+        self.assertTrue(nodes[4].target == ttnn.squeeze)
+        self.assertTrue(nodes[4].args[0].target == ttnn.to_device)
+        self.assertTrue(nodes[4].args[0].args[0].target == ttnn.to_layout)
+        self.assertTrue(nodes[4].args[0].args[0].args[0].target == ttnn.from_torch)
+        self.assertTrue(nodes[5].target == ttnn.from_device)
+        self.assertTrue(nodes[6].target == ttnn.to_layout)
+        self.assertTrue(nodes[7].target == ttnn.to_torch)
+        # Check inference result
+        self.assertTrue(torch.allclose(result_before, result_after))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_more_ops.py
+++ b/tests/test_more_ops.py
@@ -6,6 +6,7 @@ import tt_lib
 
 from torch_ttnn.utils import check_with_pcc
 
+
 class SubModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -63,6 +64,7 @@ class ReshapeModule(torch.nn.Module):
     def output_shapes(self):
         return [(2 * 32, 32)]
 
+
 class ReshapeNegativeModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -75,6 +77,7 @@ class ReshapeNegativeModule(torch.nn.Module):
 
     def output_shapes(self):
         return [(-1,)]
+
 
 class Reshape4DModule(torch.nn.Module):
     def __init__(self):
@@ -89,6 +92,7 @@ class Reshape4DModule(torch.nn.Module):
     def output_shapes(self):
         return [(16, 32, 64, 32)]
 
+
 class Reshape4DNegativeModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -102,6 +106,7 @@ class Reshape4DNegativeModule(torch.nn.Module):
     def output_shapes(self):
         return [(1, -1, 2, 32)]
 
+
 class PermuteModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -111,6 +116,7 @@ class PermuteModule(torch.nn.Module):
 
     def input_shapes(self):
         return [(4, 4)]
+
 
 class ReluModule(torch.nn.Module):
     def __init__(self):
@@ -122,6 +128,7 @@ class ReluModule(torch.nn.Module):
     def input_shapes(self):
         return [(4, 4)]
 
+
 class AddMmModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -131,6 +138,7 @@ class AddMmModule(torch.nn.Module):
 
     def input_shapes(self):
         return [(4, 4), (4, 4), (4, 4)]
+
 
 class DivModule(torch.nn.Module):
     def __init__(self):
@@ -142,6 +150,7 @@ class DivModule(torch.nn.Module):
     def input_shapes(self):
         return [(4, 4), (4, 4)]
 
+
 class DivScalarDenomModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -151,6 +160,7 @@ class DivScalarDenomModule(torch.nn.Module):
 
     def input_shapes(self):
         return [(4, 4)]
+
 
 class GeluModule(torch.nn.Module):
     def __init__(self):
@@ -162,6 +172,7 @@ class GeluModule(torch.nn.Module):
     def input_shapes(self):
         return [(4, 4)]
 
+
 class RSubModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -171,6 +182,7 @@ class RSubModule(torch.nn.Module):
 
     def input_shapes(self):
         return [(4, 4), (4, 4)]
+
 
 class RSubScalarModule(torch.nn.Module):
     def __init__(self):
@@ -182,6 +194,7 @@ class RSubScalarModule(torch.nn.Module):
     def input_shapes(self):
         return [(4, 4)]
 
+
 class EmbeddingModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -192,6 +205,7 @@ class EmbeddingModule(torch.nn.Module):
 
     def input_shapes(self):
         return [((1, 2, 4, 5), (4, 3, 2, 9)), (10, 4)]
+
 
 class EmbeddingTileLayoutModule(torch.nn.Module):
     def __init__(self):
@@ -206,7 +220,11 @@ class EmbeddingTileLayoutModule(torch.nn.Module):
         sentence_size = 384
         vocabulary_size = 250880
         hidden_embedding_dim = 1024
-        return [(0, vocabulary_size - 1, (batch_size, sentence_size)), ((vocabulary_size, hidden_embedding_dim))]
+        return [
+            (0, vocabulary_size - 1, (batch_size, sentence_size)),
+            ((vocabulary_size, hidden_embedding_dim)),
+        ]
+
 
 class CloneFromNodeModule(torch.nn.Module):
     def __init__(self):
@@ -219,6 +237,7 @@ class CloneFromNodeModule(torch.nn.Module):
     def input_shapes(self):
         return [(4, 4)]
 
+
 class CloneFromArgModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -229,30 +248,45 @@ class CloneFromArgModule(torch.nn.Module):
     def input_shapes(self):
         return [(4, 4)]
 
+
 class LayerNormModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
 
     def forward(self, embedding, weight, bias):
-        return torch.nn.functional.layer_norm(embedding, normalized_shape = [embedding.shape[-1]], weight = weight, bias = bias)
+        return torch.nn.functional.layer_norm(
+            embedding, normalized_shape=[embedding.shape[-1]], weight=weight, bias=bias
+        )
 
     def input_shapes(self):
         batch, sentence_length, embedding_dim = 2, 32, 64
         # [embedding, weight, bias]
-        return [(batch, sentence_length, embedding_dim), (embedding_dim), (embedding_dim)]
+        return [
+            (batch, sentence_length, embedding_dim),
+            (embedding_dim),
+            (embedding_dim),
+        ]
+
 
 class LayerNormWithOtherOpModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
 
     def forward(self, embedding, weight, bias):
-        layer_norm = torch.nn.functional.layer_norm(embedding, normalized_shape = [embedding.shape[-1]], weight = weight, bias = bias)
+        layer_norm = torch.nn.functional.layer_norm(
+            embedding, normalized_shape=[embedding.shape[-1]], weight=weight, bias=bias
+        )
         return layer_norm + layer_norm
 
     def input_shapes(self):
         batch, sentence_length, embedding_dim = 2, 32, 64
         # [embedding, weight, bias]
-        return [(batch, sentence_length, embedding_dim), (embedding_dim), (embedding_dim)]
+        return [
+            (batch, sentence_length, embedding_dim),
+            (embedding_dim),
+            (embedding_dim),
+        ]
+
 
 class NegModule(torch.nn.Module):
     def __init__(self):
@@ -262,7 +296,8 @@ class NegModule(torch.nn.Module):
         return torch.neg(input)
 
     def input_shapes(self):
-        return[(4)]
+        return [(4)]
+
 
 class OnesModule(torch.nn.Module):
     def __init__(self):
@@ -272,7 +307,8 @@ class OnesModule(torch.nn.Module):
         return torch.ones(shape)
 
     def input_shapes(self):
-        return[(32, 32)]
+        return [(32, 32)]
+
 
 class TrilModule(torch.nn.Module):
     def __init__(self):
@@ -282,7 +318,8 @@ class TrilModule(torch.nn.Module):
         return torch.tril(input)
 
     def input_shapes(self):
-        return[(4, 4)]
+        return [(4, 4)]
+
 
 class ArangeModule(torch.nn.Module):
     def __init__(self):
@@ -293,7 +330,8 @@ class ArangeModule(torch.nn.Module):
         return torch.arange(end)
 
     def input_shapes(self):
-        return[100]
+        return [100]
+
 
 class ArangeStartModule(torch.nn.Module):
     def __init__(self):
@@ -305,7 +343,8 @@ class ArangeStartModule(torch.nn.Module):
 
     def input_shapes(self):
         # ttnn.arange does not support star values less than 2?
-        return[2, 100]
+        return [2, 100]
+
 
 class ArangeStartStepModule(torch.nn.Module):
     def __init__(self):
@@ -316,7 +355,8 @@ class ArangeStartStepModule(torch.nn.Module):
 
     def input_shapes(self):
         # ttnn.arange does not support star values less than 2?
-        return[4, 100, 3]
+        return [4, 100, 3]
+
 
 class EqTensorModule(torch.nn.Module):
     def __init__(self):
@@ -326,7 +366,8 @@ class EqTensorModule(torch.nn.Module):
         return torch.eq(tensor1, tensor2)
 
     def input_shapes(self):
-        return[(4, 4), (4,4)]
+        return [(4, 4), (4, 4)]
+
 
 class EqScalarModule(torch.nn.Module):
     def __init__(self):
@@ -336,7 +377,8 @@ class EqScalarModule(torch.nn.Module):
         return torch.eq(tensor, scalar)
 
     def input_shapes(self):
-        return[(64, 128)]
+        return [(64, 128)]
+
 
 class LogicalNotModule(torch.nn.Module):
     def __init__(self):
@@ -346,7 +388,8 @@ class LogicalNotModule(torch.nn.Module):
         return torch.logical_not(input)
 
     def input_shapes(self):
-        return[(4, 4)]
+        return [(4, 4)]
+
 
 class ZerosLikeModule(torch.nn.Module):
     def __init__(self):
@@ -356,17 +399,19 @@ class ZerosLikeModule(torch.nn.Module):
         return torch.zeros_like(input)
 
     def input_shapes(self):
-        return[(4, 4)]
+        return [(4, 4)]
+
 
 class MeanDimModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
 
-    def forward(self, input, dim, keepdim = False):
+    def forward(self, input, dim, keepdim=False):
         return torch.mean(input, dim, keepdim)
 
     def input_shapes(self):
-        return[(1, 32, 32), -1]
+        return [(1, 32, 32), -1]
+
 
 class PowTensorScalarModule(torch.nn.Module):
     def __init__(self):
@@ -378,7 +423,8 @@ class PowTensorScalarModule(torch.nn.Module):
         return square
 
     def input_shapes(self):
-        return[(4, 4)]
+        return [(4, 4)]
+
 
 class RsqrtModule(torch.nn.Module):
     def __init__(self):
@@ -388,7 +434,8 @@ class RsqrtModule(torch.nn.Module):
         return torch.rsqrt(input)
 
     def input_shapes(self):
-        return[(4, 4)]
+        return [(4, 4)]
+
 
 class SiluModule(torch.nn.Module):
     def __init__(self):
@@ -398,7 +445,8 @@ class SiluModule(torch.nn.Module):
         return torch.nn.functional.silu(input)
 
     def input_shapes(self):
-        return[(4, 4)]
+        return [(4, 4)]
+
 
 class AdaptiveAvgPool2dModule(torch.nn.Module):
     def __init__(self):
@@ -408,7 +456,8 @@ class AdaptiveAvgPool2dModule(torch.nn.Module):
         return torch._adaptive_avg_pool2d(input, (1, 1))
 
     def input_shapes(self):
-        return[(1, 2048, 7, 7)]
+        return [(1, 2048, 7, 7)]
+
 
 class ClampModule(torch.nn.Module):
     def __init__(self):
@@ -418,7 +467,8 @@ class ClampModule(torch.nn.Module):
         return torch.clamp(input, min=min, max=max)
 
     def input_shapes(self):
-        return[(4, 4)]
+        return [(4, 4)]
+
 
 class SqueezeDimModule(torch.nn.Module):
     def __init__(self):
@@ -428,7 +478,8 @@ class SqueezeDimModule(torch.nn.Module):
         return torch.squeeze(input, dim)
 
     def input_shapes(self):
-        return[(1, 32, 16)]
+        return [(1, 32, 16)]
+
 
 class FullModule(torch.nn.Module):
     def __init__(self):
@@ -438,7 +489,8 @@ class FullModule(torch.nn.Module):
         return torch.full(size, fill_value)
 
     def input_shapes(self):
-        return[(64, 128)]
+        return [(64, 128)]
+
 
 class LtTensorModule(torch.nn.Module):
     def __init__(self):
@@ -448,7 +500,8 @@ class LtTensorModule(torch.nn.Module):
         return torch.lt(input, tensor)
 
     def input_shapes(self):
-        return[(4, 4), (4, 4)]
+        return [(4, 4), (4, 4)]
+
 
 class LtScalarModule(torch.nn.Module):
     def __init__(self):
@@ -458,25 +511,27 @@ class LtScalarModule(torch.nn.Module):
         return torch.lt(input, scalar)
 
     def input_shapes(self):
-        return[(64, 128)]
+        return [(64, 128)]
+
 
 class BaddbmmModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
 
-    def forward(self, input, batch1, batch2, beta = 1, alpha = 1):
+    def forward(self, input, batch1, batch2, beta=1, alpha=1):
         if beta == 1:
-            return torch.baddbmm(input, batch1, batch2, alpha = alpha)
+            return torch.baddbmm(input, batch1, batch2, alpha=alpha)
         elif alpha == 1:
-            return torch.baddbmm(input, batch1, batch2, beta = beta)
+            return torch.baddbmm(input, batch1, batch2, beta=beta)
         elif beta == 1 and alpha == 1:
             return torch.baddbmm(input, batch1, batch2)
         else:
-            return torch.baddbmm(input, batch1, batch2, beta = beta, alpha = alpha)
+            return torch.baddbmm(input, batch1, batch2, beta=beta, alpha=alpha)
 
     def input_shapes(self):
         # input, batch1, batch2
-        return[(10, 64, 128), (10, 64, 32), (10, 32, 128)]
+        return [(10, 64, 128), (10, 64, 32), (10, 32, 128)]
+
 
 class CosModule(torch.nn.Module):
     def __init__(self):
@@ -488,6 +543,7 @@ class CosModule(torch.nn.Module):
     def input_shapes(self):
         return [(4, 4)]
 
+
 class SigmoidModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -498,10 +554,11 @@ class SigmoidModule(torch.nn.Module):
     def input_shapes(self):
         return [(4, 4)]
 
+
 class TestModules(unittest.TestCase):
     def setUp(self):
         # Open device 0
-        self.device: ttnn.Device = ttnn.open_device(device_id = 0)
+        self.device: ttnn.Device = ttnn.open_device(device_id=0)
         # For AutoFormat
         tt_lib.device.SetDefaultDevice(self.device)
 
@@ -958,7 +1015,9 @@ class TestModules(unittest.TestCase):
         m = EmbeddingTileLayoutModule()
         input_shapes = m.input_shapes()
         input = torch.randint(*input_shapes[0])
-        weights = torch.zeros(*input_shapes[1], dtype=torch.bfloat16).uniform_(-0.1, 0.1)
+        weights = torch.zeros(*input_shapes[1], dtype=torch.bfloat16).uniform_(
+            -0.1, 0.1
+        )
         result_before = m.forward(input, weights)
         option = torch_ttnn.TorchTtnnOption(device=self.device)
         option.gen_graphviz = True
@@ -1047,10 +1106,14 @@ class TestModules(unittest.TestCase):
         self.assertTrue(nodes[12].args[0].args[0].args[0].target == ttnn.from_torch)
         self.assertTrue(nodes[12].kwargs["weight"].target == ttnn.to_device)
         self.assertTrue(nodes[12].kwargs["weight"].args[0].target == ttnn.to_layout)
-        self.assertTrue(nodes[12].kwargs["weight"].args[0].args[0].target == ttnn.from_torch)
+        self.assertTrue(
+            nodes[12].kwargs["weight"].args[0].args[0].target == ttnn.from_torch
+        )
         self.assertTrue(nodes[12].kwargs["bias"].target == ttnn.to_device)
         self.assertTrue(nodes[12].kwargs["bias"].args[0].target == ttnn.to_layout)
-        self.assertTrue(nodes[12].kwargs["bias"].args[0].args[0].target == ttnn.from_torch)
+        self.assertTrue(
+            nodes[12].kwargs["bias"].args[0].args[0].target == ttnn.from_torch
+        )
         self.assertTrue(nodes[13].target == ttnn.from_device)
         self.assertTrue(nodes[14].target == ttnn.to_layout)
         self.assertTrue(nodes[15].target == ttnn.to_torch)
@@ -1224,7 +1287,9 @@ class TestModules(unittest.TestCase):
     def test_eq_tensor(self):
         m = EqTensorModule()
         input_shapes = m.input_shapes()
-        inputs = [torch.randint(0, 2, shape, dtype=torch.bfloat16) for shape in input_shapes]
+        inputs = [
+            torch.randint(0, 2, shape, dtype=torch.bfloat16) for shape in input_shapes
+        ]
         result_before = m.forward(*inputs)
         option = torch_ttnn.TorchTtnnOption(device=self.device)
         option.gen_graphviz = True
@@ -1251,7 +1316,9 @@ class TestModules(unittest.TestCase):
     def test_eq_scalar(self):
         m = EqScalarModule()
         input_shapes = m.input_shapes()
-        inputs = [torch.randint(0, 2, shape, dtype=torch.bfloat16) for shape in input_shapes]
+        inputs = [
+            torch.randint(0, 2, shape, dtype=torch.bfloat16) for shape in input_shapes
+        ]
         scalar = torch.randint(0, 2, (1,)).item()
         result_before = m.forward(inputs[0], scalar)
         option = torch_ttnn.TorchTtnnOption(device=self.device)
@@ -1601,9 +1668,9 @@ class TestModules(unittest.TestCase):
         self.assertTrue(check_with_pcc(result_before, result_after))
 
         # (2) Test with alpha and default beta value
-        result_before = m.forward(*inputs, alpha = 2)
+        result_before = m.forward(*inputs, alpha=2)
         m_ttnn = torch.compile(m, backend=torch_ttnn.backend, options=option)
-        result_after = m_ttnn.forward(*inputs, alpha = 2)
+        result_after = m_ttnn.forward(*inputs, alpha=2)
         option._out_fx_graphs[-1].print_tabular()
 
         nodes = list(option._out_fx_graphs[-1].nodes)
@@ -1627,9 +1694,9 @@ class TestModules(unittest.TestCase):
         self.assertTrue(check_with_pcc(result_before, result_after))
 
         # (3) Test with beta and default alpha value
-        result_before = m.forward(*inputs, beta = 2)
+        result_before = m.forward(*inputs, beta=2)
         m_ttnn = torch.compile(m, backend=torch_ttnn.backend, options=option)
-        result_after = m_ttnn.forward(*inputs, beta = 2)
+        result_after = m_ttnn.forward(*inputs, beta=2)
         option._out_fx_graphs[-1].print_tabular()
 
         nodes = list(option._out_fx_graphs[-1].nodes)
@@ -1653,9 +1720,9 @@ class TestModules(unittest.TestCase):
         self.assertTrue(check_with_pcc(result_before, result_after))
 
         # (4) Test with beta and alpha values
-        result_before = m.forward(*inputs, beta = 2, alpha = 2)
+        result_before = m.forward(*inputs, beta=2, alpha=2)
         m_ttnn = torch.compile(m, backend=torch_ttnn.backend, options=option)
-        result_after = m_ttnn.forward(*inputs, beta = 2, alpha = 2)
+        result_after = m_ttnn.forward(*inputs, beta=2, alpha=2)
         option._out_fx_graphs[-1].print_tabular()
 
         nodes = list(option._out_fx_graphs[-1].nodes)
@@ -1681,9 +1748,9 @@ class TestModules(unittest.TestCase):
         self.assertTrue(check_with_pcc(result_before, result_after))
 
         # (5) Test special case when beta is 0
-        result_before = m.forward(*inputs, beta = 0, alpha = 2)
+        result_before = m.forward(*inputs, beta=0, alpha=2)
         m_ttnn = torch.compile(m, backend=torch_ttnn.backend, options=option)
-        result_after = m_ttnn.forward(*inputs, beta = 0, alpha = 2)
+        result_after = m_ttnn.forward(*inputs, beta=0, alpha=2)
         option._out_fx_graphs[-1].print_tabular()
 
         nodes = list(option._out_fx_graphs[-1].nodes)
@@ -1748,6 +1815,7 @@ class TestModules(unittest.TestCase):
         self.assertTrue(nodes[7].target == ttnn.to_torch)
         # Check inference result
         self.assertTrue(torch.allclose(result_before, result_after, rtol=0.2))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_more_ops.py
+++ b/tests/test_more_ops.py
@@ -152,6 +152,27 @@ class SplitModule(torch.nn.Module):
     def input_shapes(self):
         return [(2, 4)]
 
+class CloneFromNodeModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input):
+        a = input + input
+        return torch.clone(a)
+
+    def input_shapes(self):
+        return [(4, 4)]
+
+class CloneFromArgModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, input):
+        return torch.clone(input)
+
+    def input_shapes(self):
+        return [(4, 4)]
+
 class TestModules(unittest.TestCase):
     def setUp(self):
         # Open device 0
@@ -521,6 +542,54 @@ class TestModules(unittest.TestCase):
         self.assertTrue(len(result_before) == len(result_after))
         for before, after in zip(result_before, result_after):
             self.assertTrue(torch.allclose(before, after))
+
+    def test_clone_from_arg(self):
+        m = CloneFromArgModule()
+        input_shapes = m.input_shapes()
+        inputs = [torch.rand(shape, dtype=torch.bfloat16) for shape in input_shapes]
+        result_before = m.forward(*inputs)
+        option = torch_ttnn.TorchTtnnOption(device=self.device)
+        option.gen_graphviz = False
+        # The compilation is lazy, so we need to run forward once to trigger the compilation
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+        result_after = m.forward(*inputs)
+        option._out_fx_graphs[0].print_tabular()
+
+        # Check the graph has be rewritten and contain ttnn ops
+        nodes = list(option._out_fx_graphs[0].nodes)
+        self.assertTrue(nodes[5].target == ttnn.clone)
+        self.assertTrue(nodes[5].args[0].target == ttnn.to_device)
+        self.assertTrue(nodes[5].args[0].args[0].target == ttnn.to_layout)
+        self.assertTrue(nodes[5].args[0].args[0].args[0].target == ttnn.from_torch)
+        self.assertTrue(nodes[5].args[1].target == ttnn.MemoryConfig)
+        self.assertTrue(nodes[6].target == ttnn.from_device)
+        self.assertTrue(nodes[7].target == ttnn.to_layout)
+        self.assertTrue(nodes[8].target == ttnn.to_torch)
+        # Check inference result
+        self.assertTrue(torch.allclose(result_before, result_after))
+
+    def test_clone_from_node(self):
+        m = CloneFromNodeModule()
+        input_shapes = m.input_shapes()
+        inputs = [torch.rand(shape, dtype=torch.bfloat16) for shape in input_shapes]
+        result_before = m.forward(*inputs)
+        option = torch_ttnn.TorchTtnnOption(device=self.device)
+        option.gen_graphviz = False
+        # The compilation is lazy, so we need to run forward once to trigger the compilation
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+        result_after = m.forward(*inputs)
+        option._out_fx_graphs[0].print_tabular()
+
+        # Check the graph has be rewritten and contain ttnn ops
+        nodes = list(option._out_fx_graphs[0].nodes)
+        self.assertTrue(nodes[6].target == ttnn.clone)
+        self.assertTrue(nodes[6].args[0].target == ttnn.add)
+        self.assertTrue(nodes[6].args[1].target == ttnn.MemoryConfig)
+        self.assertTrue(nodes[7].target == ttnn.from_device)
+        self.assertTrue(nodes[8].target == ttnn.to_layout)
+        self.assertTrue(nodes[9].target == ttnn.to_torch)
+        # Check inference result
+        self.assertTrue(torch.allclose(result_before, result_after))
 
 
 if __name__ == "__main__":

--- a/tests/test_more_ops.py
+++ b/tests/test_more_ops.py
@@ -173,6 +173,18 @@ class CloneFromArgModule(torch.nn.Module):
     def input_shapes(self):
         return [(4, 4)]
 
+class LayerNormModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, embedding, weight, bias):
+        return torch.nn.functional.layer_norm(embedding, normalized_shape = [embedding.shape[-1]], weight = weight, bias = bias)
+
+    def input_shapes(self):
+        batch, sentence_length, embedding_dim = 2, 32, 64
+        # [embedding, weight, bias]
+        return [(batch, sentence_length, embedding_dim), (embedding_dim), (embedding_dim)]
+
 class TestModules(unittest.TestCase):
     def setUp(self):
         # Open device 0
@@ -590,6 +602,36 @@ class TestModules(unittest.TestCase):
         self.assertTrue(nodes[9].target == ttnn.to_torch)
         # Check inference result
         self.assertTrue(torch.allclose(result_before, result_after))
+
+    def test_layer_norm(self):
+        m = LayerNormModule()
+        input_shapes = m.input_shapes()
+        inputs = [torch.rand(shape, dtype=torch.bfloat16) for shape in input_shapes]
+        result_before = m.forward(*inputs)
+        option = torch_ttnn.TorchTtnnOption(device=self.device)
+        option.gen_graphviz = True
+        # The compilation is lazy, so we need to run forward once to trigger the compilation
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+        result_after = m.forward(*inputs)
+        option._out_fx_graphs[0].print_tabular()
+
+        # Check the graph has be rewritten and contain ttnn ops
+        nodes = list(option._out_fx_graphs[0].nodes)
+        self.assertTrue(nodes[12].target == ttnn.layer_norm)
+        self.assertTrue(nodes[12].args[0].target == ttnn.to_device)
+        self.assertTrue(nodes[12].args[0].args[0].target == ttnn.to_layout)
+        self.assertTrue(nodes[12].args[0].args[0].args[0].target == ttnn.from_torch)
+        self.assertTrue(nodes[12].kwargs["weight"].target == ttnn.to_device)
+        self.assertTrue(nodes[12].kwargs["weight"].args[0].target == ttnn.to_layout)
+        self.assertTrue(nodes[12].kwargs["weight"].args[0].args[0].target == ttnn.from_torch)
+        self.assertTrue(nodes[12].kwargs["bias"].target == ttnn.to_device)
+        self.assertTrue(nodes[12].kwargs["bias"].args[0].target == ttnn.to_layout)
+        self.assertTrue(nodes[12].kwargs["bias"].args[0].args[0].target == ttnn.from_torch)
+        self.assertTrue(nodes[13].target == ttnn.to_layout)
+        self.assertTrue(nodes[14].target == ttnn.from_device)
+        self.assertTrue(nodes[15].target == ttnn.to_torch)
+        # Check inference result
+        self.assertTrue(check_with_pcc(result_before, result_after, 0.9998))
 
 
 if __name__ == "__main__":

--- a/tests/test_more_ops.py
+++ b/tests/test_more_ops.py
@@ -139,7 +139,7 @@ class TestModules(unittest.TestCase):
         option = torch_ttnn.TorchTtnnOption(device=self.device)
         option.gen_graphviz = True
         # The compilation is lazy, so we need to run forward once to trigger the compilation
-        m = torch.compile(m, backend=torch_ttnn.backend(option))
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
         result_after = m.forward(*inputs)
         option._out_fx_graphs[0].print_tabular()
 
@@ -165,7 +165,7 @@ class TestModules(unittest.TestCase):
         option = torch_ttnn.TorchTtnnOption(device=self.device)
         option.gen_graphviz = True
         # The compilation is lazy, so we need to run forward once to trigger the compilation
-        m = torch.compile(m, backend=torch_ttnn.backend(option))
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
         result_after = m.forward(*inputs)
         option._out_fx_graphs[0].print_tabular()
 
@@ -190,7 +190,7 @@ class TestModules(unittest.TestCase):
         option = torch_ttnn.TorchTtnnOption(device=self.device)
         option.gen_graphviz = True
         # The compilation is lazy, so we need to run forward once to trigger the compilation
-        m = torch.compile(m, backend=torch_ttnn.backend(option))
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
         result_after = m.forward(*inputs, axis)
         option._out_fx_graphs[0].print_tabular()
 
@@ -214,7 +214,7 @@ class TestModules(unittest.TestCase):
         option = torch_ttnn.TorchTtnnOption(device=self.device)
         option.gen_graphviz = True
         # The compilation is lazy, so we need to run forward once to trigger the compilation
-        m = torch.compile(m, backend=torch_ttnn.backend(option))
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
         result_after = m.forward(*inputs)
         option._out_fx_graphs[0].print_tabular()
 
@@ -239,7 +239,7 @@ class TestModules(unittest.TestCase):
         option = torch_ttnn.TorchTtnnOption(device=self.device)
         option.gen_graphviz = True
         # The compilation is lazy, so we need to run forward once to trigger the compilation
-        m = torch.compile(m, backend=torch_ttnn.backend(option))
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
         result_after = m.forward(*inputs, new_shape)
         option._out_fx_graphs[0].print_tabular()
 
@@ -260,7 +260,7 @@ class TestModules(unittest.TestCase):
         option = torch_ttnn.TorchTtnnOption(device=self.device)
         option.gen_graphviz = True
         # The compilation is lazy, so we need to run forward once to trigger the compilation
-        m = torch.compile(m, backend=torch_ttnn.backend(option))
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
         result_after = m.forward(*inputs, new_shape)
         option._out_fx_graphs[0].print_tabular()
 
@@ -287,7 +287,7 @@ class TestModules(unittest.TestCase):
         option = torch_ttnn.TorchTtnnOption(device=self.device)
         option.gen_graphviz = True
         # The compilation is lazy, so we need to run forward once to trigger the compilation
-        m = torch.compile(m, backend=torch_ttnn.backend(option))
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
         result_after = m.forward(*inputs, order)
         option._out_fx_graphs[0].print_tabular()
 
@@ -311,7 +311,7 @@ class TestModules(unittest.TestCase):
         option = torch_ttnn.TorchTtnnOption(device=self.device)
         option.gen_graphviz = True
         # The compilation is lazy, so we need to run forward once to trigger the compilation
-        m = torch.compile(m, backend=torch_ttnn.backend(option))
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
         result_after = m.forward(*inputs)
         option._out_fx_graphs[0].print_tabular()
 
@@ -335,7 +335,7 @@ class TestModules(unittest.TestCase):
         option = torch_ttnn.TorchTtnnOption(device=self.device)
         option.gen_graphviz = True
         # The compilation is lazy, so we need to run forward once to trigger the compilation
-        m = torch.compile(m, backend=torch_ttnn.backend(option))
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
         result_after = m.forward(*inputs)
         option._out_fx_graphs[0].print_tabular()
 
@@ -367,7 +367,7 @@ class TestModules(unittest.TestCase):
         option = torch_ttnn.TorchTtnnOption(device=self.device)
         option.gen_graphviz = True
         # The compilation is lazy, so we need to run forward once to trigger the compilation
-        m = torch.compile(m, backend=torch_ttnn.backend(option))
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
         result_after = m.forward(*inputs)
         option._out_fx_graphs[0].print_tabular()
 
@@ -396,7 +396,7 @@ class TestModules(unittest.TestCase):
         option = torch_ttnn.TorchTtnnOption(device=self.device)
         option.gen_graphviz = True
         # The compilation is lazy, so we need to run forward once to trigger the compilation
-        m = torch.compile(m, backend=torch_ttnn.backend(option))
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
         result_after = m.forward(*inputs)
         option._out_fx_graphs[0].print_tabular()
 

--- a/tests/test_more_ops.py
+++ b/tests/test_more_ops.py
@@ -58,6 +58,17 @@ class ReshapeModule(torch.nn.Module):
     def input_shapes(self):
         return [(4, 4)]
 
+# Why can't we reuse ReshapeModule?
+class ReshapeModule4D(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x, new_shape):
+        return torch.reshape(x, new_shape)
+
+    def input_shapes(self):
+        return [(4, 4, 4, 4)]
+
 
 class PermuteModule(torch.nn.Module):
     def __init__(self):
@@ -183,6 +194,27 @@ class TestModules(unittest.TestCase):
         input_shapes = m.input_shapes()
         inputs = [torch.rand(shape, dtype=torch.bfloat16) for shape in input_shapes]
         new_shape = (2, 8)
+        result_before = m.forward(*inputs, new_shape)
+        option = torch_ttnn.TorchTtnnOption(device=self.device)
+        option.gen_graphviz = True
+        # The compilation is lazy, so we need to run forward once to trigger the compilation
+        m = torch.compile(m, backend=torch_ttnn.backend(option))
+        result_after = m.forward(*inputs, new_shape)
+        option._out_fx_graphs[0].print_tabular()
+
+        # Check the graph has be rewritten and contain ttnn ops
+        nodes = list(option._out_fx_graphs[0].nodes)
+        self.assertTrue(nodes[2].target == ttnn.reshape)
+        self.assertTrue(nodes[2].args[0].target == ttnn.from_torch)
+        self.assertTrue(nodes[3].target == ttnn.to_torch)
+        # Check inference result
+        self.assertTrue(torch.allclose(result_before, result_after))
+
+    def test_reshape_4d(self):
+        m = ReshapeModule4D()
+        input_shapes = m.input_shapes()
+        inputs = [torch.rand(shape, dtype=torch.bfloat16) for shape in input_shapes]
+        new_shape = (2, 8, 8, 2)
         result_before = m.forward(*inputs, new_shape)
         option = torch_ttnn.TorchTtnnOption(device=self.device)
         option.gen_graphviz = True

--- a/tests/test_only_add_matmul.py
+++ b/tests/test_only_add_matmul.py
@@ -5,6 +5,7 @@ from torch_ttnn import ttnn
 
 from torch_ttnn.utils import check_with_pcc
 
+
 class AddModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -55,7 +56,7 @@ class AddMatmulModule(torch.nn.Module):
 class TestModules(unittest.TestCase):
     def setUp(self):
         # Open device 0
-        self.device: ttnn.Device = ttnn.open_device(device_id = 0)
+        self.device: ttnn.Device = ttnn.open_device(device_id=0)
 
     def tearDown(self):
         # Close the device
@@ -117,9 +118,7 @@ class TestModules(unittest.TestCase):
     def test_batchmatmul(self):
         m = BatchMatmulModule()
         input_shapes = m.input_shapes()
-        inputs = [
-            torch.rand(shape).type(torch.bfloat16) for shape in input_shapes
-        ]
+        inputs = [torch.rand(shape).type(torch.bfloat16) for shape in input_shapes]
         result_before = m.forward(*inputs)
         option = torch_ttnn.TorchTtnnOption(device=self.device)
         option.gen_graphviz = True

--- a/tests/test_only_add_matmul.py
+++ b/tests/test_only_add_matmul.py
@@ -43,11 +43,11 @@ class AddMatmulModule(torch.nn.Module):
 class TestModules(unittest.TestCase):
     def setUp(self):
         # Open device 0
-        self.device: ttnn.Device = ttnn.open(0)
+        self.device: ttnn.Device = ttnn.open_device(device_id = 0)
 
     def tearDown(self):
         # Close the device
-        ttnn.close(self.device)
+        ttnn.close_device(self.device)
 
     def test_add(self):
         m = AddModule()
@@ -65,12 +65,13 @@ class TestModules(unittest.TestCase):
 
         # Check the graph has be rewritten and contain ttnn ops
         nodes = list(option._out_fx_graphs[0].nodes)
-        self.assertEqual(nodes[6].target, ttnn.add)
-        self.assertEqual(nodes[6].args[0].target, ttnn.to_device)
-        self.assertEqual(nodes[6].args[0].args[0].target, ttnn.from_torch)
-        self.assertEqual(nodes[7].target, ttnn.from_device)
-        self.assertEqual(nodes[8].target, ttnn.to_layout)
-        self.assertEqual(nodes[9].target, ttnn.to_torch)
+        self.assertEqual(nodes[8].target, ttnn.add)
+        self.assertEqual(nodes[8].args[0].target, ttnn.to_device)
+        self.assertEqual(nodes[8].args[0].args[0].target, ttnn.to_layout)
+        self.assertEqual(nodes[8].args[0].args[0].args[0].target, ttnn.from_torch)
+        self.assertEqual(nodes[9].target, ttnn.from_device)
+        self.assertEqual(nodes[10].target, ttnn.to_layout)
+        self.assertEqual(nodes[11].target, ttnn.to_torch)
         # Check inference result
         self.assertTrue(torch.allclose(result_before, result_after))
 
@@ -91,12 +92,13 @@ class TestModules(unittest.TestCase):
 
         # Check the graph has be rewritten and contain ttnn ops
         nodes = list(option._out_fx_graphs[0].nodes)
-        self.assertEqual(nodes[6].target, ttnn.matmul)
-        self.assertEqual(nodes[6].args[0].target, ttnn.to_device)
-        self.assertEqual(nodes[6].args[0].args[0].target, ttnn.from_torch)
-        self.assertEqual(nodes[7].target, ttnn.from_device)
-        self.assertEqual(nodes[8].target, ttnn.to_layout)
-        self.assertEqual(nodes[9].target, ttnn.to_torch)
+        self.assertEqual(nodes[8].target, ttnn.matmul)
+        self.assertEqual(nodes[8].args[0].target, ttnn.to_device)
+        self.assertEqual(nodes[8].args[0].args[0].target, ttnn.to_layout)
+        self.assertEqual(nodes[8].args[0].args[0].args[0].target, ttnn.from_torch)
+        self.assertEqual(nodes[9].target, ttnn.from_device)
+        self.assertEqual(nodes[10].target, ttnn.to_layout)
+        self.assertEqual(nodes[11].target, ttnn.to_torch)
         # Check inference result
         self.assertTrue(torch.allclose(result_before, result_after))
 
@@ -117,13 +119,14 @@ class TestModules(unittest.TestCase):
 
         # Check the graph has be rewritten and contain ttnn ops
         nodes = list(option._out_fx_graphs[0].nodes)
-        self.assertEqual(nodes[6].target, ttnn.add)
-        self.assertEqual(nodes[6].args[0].target, ttnn.to_device)
-        self.assertEqual(nodes[6].args[0].args[0].target, ttnn.from_torch)
-        self.assertEqual(nodes[7].target, ttnn.matmul)
-        self.assertEqual(nodes[8].target, ttnn.from_device)
-        self.assertEqual(nodes[9].target, ttnn.to_layout)
-        self.assertEqual(nodes[10].target, ttnn.to_torch)
+        self.assertEqual(nodes[8].target, ttnn.add)
+        self.assertEqual(nodes[8].args[0].target, ttnn.to_device)
+        self.assertEqual(nodes[8].args[0].args[0].target, ttnn.to_layout)
+        self.assertEqual(nodes[8].args[0].args[0].args[0].target, ttnn.from_torch)
+        self.assertEqual(nodes[9].target, ttnn.matmul)
+        self.assertEqual(nodes[10].target, ttnn.from_device)
+        self.assertEqual(nodes[11].target, ttnn.to_layout)
+        self.assertEqual(nodes[12].target, ttnn.to_torch)
         # Check inference result
         self.assertTrue(torch.allclose(result_before, result_after))
 

--- a/tests/test_only_add_matmul.py
+++ b/tests/test_only_add_matmul.py
@@ -3,7 +3,7 @@ import torch_ttnn
 import unittest
 from torch_ttnn import ttnn
 
-from tests.ttnn.utils_for_testing import check_with_pcc
+from torch_ttnn.utils import check_with_pcc
 
 class AddModule(torch.nn.Module):
     def __init__(self):

--- a/tests/test_only_add_matmul.py
+++ b/tests/test_only_add_matmul.py
@@ -3,6 +3,7 @@ import torch_ttnn
 import unittest
 from torch_ttnn import ttnn
 
+from tests.ttnn.utils_for_testing import check_with_pcc
 
 class AddModule(torch.nn.Module):
     def __init__(self):
@@ -24,6 +25,17 @@ class MatmulModule(torch.nn.Module):
 
     def input_shapes(self):
         return [(32, 32), (32, 32)]
+
+
+class BatchMatmulModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x, y):
+        return torch.bmm(x, y)
+
+    def input_shapes(self):
+        return [(10, 64, 32), (10, 32, 128)]
 
 
 # Nested module for demonstration, verify nested modules work
@@ -101,6 +113,36 @@ class TestModules(unittest.TestCase):
         self.assertEqual(nodes[11].target, ttnn.to_torch)
         # Check inference result
         self.assertTrue(torch.allclose(result_before, result_after))
+
+    def test_batchmatmul(self):
+        m = BatchMatmulModule()
+        input_shapes = m.input_shapes()
+        inputs = [
+            torch.rand(shape).type(torch.bfloat16) for shape in input_shapes
+        ]
+        result_before = m.forward(*inputs)
+        option = torch_ttnn.TorchTtnnOption(device=self.device)
+        option.gen_graphviz = True
+        # The compilation is lazy, so we need to run forward once to trigger the compilation
+        m = torch.compile(m, backend=torch_ttnn.backend(option))
+        result_after = m.forward(*inputs)
+        self.assertEqual(1, len(option._out_fx_graphs))
+        option._out_fx_graphs[0].print_tabular()
+
+        # Check the graph has be rewritten and contain ttnn ops
+        nodes = list(option._out_fx_graphs[0].nodes)
+        self.assertEqual(nodes[8].target, ttnn.matmul)
+        self.assertEqual(nodes[8].args[0].target, ttnn.to_device)
+        self.assertEqual(nodes[8].args[0].args[0].target, ttnn.to_layout)
+        self.assertEqual(nodes[8].args[0].args[0].args[0].target, ttnn.from_torch)
+        self.assertEqual(nodes[8].args[1].target, ttnn.to_device)
+        self.assertEqual(nodes[8].args[1].args[0].target, ttnn.to_layout)
+        self.assertEqual(nodes[8].args[1].args[0].args[0].target, ttnn.from_torch)
+        self.assertEqual(nodes[9].target, ttnn.from_device)
+        self.assertEqual(nodes[10].target, ttnn.to_layout)
+        self.assertEqual(nodes[11].target, ttnn.to_torch)
+        # Check inference result
+        self.assertTrue(check_with_pcc(result_before, result_after))
 
     def test_add_and_matmul(self):
         m = AddMatmulModule()

--- a/tests/test_only_add_matmul.py
+++ b/tests/test_only_add_matmul.py
@@ -70,7 +70,7 @@ class TestModules(unittest.TestCase):
         result_before = m.forward(*inputs)
         option = torch_ttnn.TorchTtnnOption(device=self.device)
         # The compilation is lazy, so we need to run forward once to trigger the compilation
-        m = torch.compile(m, backend=torch_ttnn.backend(option))
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
         result_after = m.forward(*inputs)
         self.assertEqual(1, len(option._out_fx_graphs))
         option._out_fx_graphs[0].print_tabular()
@@ -97,7 +97,7 @@ class TestModules(unittest.TestCase):
         option = torch_ttnn.TorchTtnnOption(device=self.device)
         option.gen_graphviz = True
         # The compilation is lazy, so we need to run forward once to trigger the compilation
-        m = torch.compile(m, backend=torch_ttnn.backend(option))
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
         result_after = m.forward(*inputs)
         self.assertEqual(1, len(option._out_fx_graphs))
         option._out_fx_graphs[0].print_tabular()
@@ -124,7 +124,7 @@ class TestModules(unittest.TestCase):
         option = torch_ttnn.TorchTtnnOption(device=self.device)
         option.gen_graphviz = True
         # The compilation is lazy, so we need to run forward once to trigger the compilation
-        m = torch.compile(m, backend=torch_ttnn.backend(option))
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
         result_after = m.forward(*inputs)
         self.assertEqual(1, len(option._out_fx_graphs))
         option._out_fx_graphs[0].print_tabular()
@@ -154,7 +154,7 @@ class TestModules(unittest.TestCase):
         option = torch_ttnn.TorchTtnnOption(device=self.device)
         option.gen_graphviz = True
         # The compilation is lazy, so we need to run forward once to trigger the compilation
-        m = torch.compile(m, backend=torch_ttnn.backend(option))
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
         result_after = m.forward(*inputs)
         self.assertEqual(1, len(option._out_fx_graphs))
         option._out_fx_graphs[0].print_tabular()

--- a/tests/test_real_world.py
+++ b/tests/test_real_world.py
@@ -9,11 +9,11 @@ import collections
 class TestRealWorld(unittest.TestCase):
     def setUp(self):
         # Open device 0
-        self.device: ttnn.Device = ttnn.open(0)
+        self.device: ttnn.Device = ttnn.open_device(device_id = 0)
 
     def tearDown(self):
         # Close the device
-        ttnn.close(self.device)
+        ttnn.close_device(self.device)
 
     @unittest.skip(
         "Skip this test because it take 135 MB to download the ResNet18 model. Un-skip it if you want to test it."

--- a/tests/test_real_world.py
+++ b/tests/test_real_world.py
@@ -9,7 +9,7 @@ import collections
 class TestRealWorld(unittest.TestCase):
     def setUp(self):
         # Open device 0
-        self.device: ttnn.Device = ttnn.open_device(device_id = 0)
+        self.device: ttnn.Device = ttnn.open_device(device_id=0)
 
     def tearDown(self):
         # Close the device

--- a/tests/test_type_conversion.py
+++ b/tests/test_type_conversion.py
@@ -1,0 +1,88 @@
+import torch
+import torch_ttnn
+import unittest
+from torch_ttnn import ttnn
+import tt_lib
+
+from tests.ttnn.utils_for_testing import check_with_pcc
+
+class MulModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x, y):
+        return torch.mul(x, y)
+
+    def input_shapes(self):
+        return [(4, 4), (4, 4)]
+
+class TestModules(unittest.TestCase):
+    def setUp(self):
+        # Open device 0
+        self.device: ttnn.Device = ttnn.open_device(device_id = 0)
+        # For AutoFormat
+        tt_lib.device.SetDefaultDevice(self.device)
+
+    def tearDown(self):
+        # Close the device
+        ttnn.close_device(self.device)
+
+    def test_mul(self):
+        m = MulModule()
+        input_shapes = m.input_shapes()
+        inputs = [
+            torch.randint(1, 5, shape).type(torch.float32) for shape in input_shapes
+        ]
+        result_before = m.forward(*inputs)
+        option = torch_ttnn.TorchTtnnOption(device=self.device)
+        option.gen_graphviz = True
+        # The compilation is lazy, so we need to run forward once to trigger the compilation
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+        result_after = m.forward(*inputs)
+        option._out_fx_graphs[0].print_tabular()
+
+        # Check the graph has be rewritten and contain ttnn ops
+        nodes = list(option._out_fx_graphs[0].nodes)
+        self.assertTrue(nodes[10].target == ttnn.mul)
+        self.assertTrue(nodes[10].args[0].target == ttnn.to_device)
+        self.assertTrue(nodes[10].args[0].args[0].target == ttnn.to_layout)
+        self.assertTrue(nodes[10].args[0].args[0].args[0].target == ttnn.from_torch)
+        self.assertTrue(nodes[10].args[1].target == ttnn.to_device)
+        self.assertTrue(nodes[10].args[1].args[0].target == ttnn.to_layout)
+        self.assertTrue(nodes[10].args[1].args[0].args[0].target == ttnn.from_torch)
+        self.assertTrue(nodes[11].target == ttnn.from_device)
+        self.assertTrue(nodes[12].target == ttnn.to_layout)
+        self.assertTrue(nodes[13].target == ttnn.to_torch)
+        # Check inference result
+        self.assertTrue(torch.allclose(result_before.to(torch.bfloat16), result_after))
+
+    def test_mul_scalar(self):
+        m = MulModule()
+        input_shapes = m.input_shapes()
+        inputs = [
+            torch.randint(1, 5, input_shapes[0]).type(torch.float32),
+            torch.randint(1, 5, (1,)).type(torch.float32).item(),
+        ]
+        print(inputs)
+        result_before = m.forward(*inputs)
+        option = torch_ttnn.TorchTtnnOption(device=self.device)
+        option.gen_graphviz = True
+        # The compilation is lazy, so we need to run forward once to trigger the compilation
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+        result_after = m.forward(*inputs)
+        option._out_fx_graphs[0].print_tabular()
+
+        # Check the graph has be rewritten and contain ttnn ops
+        nodes = list(option._out_fx_graphs[0].nodes)
+        self.assertTrue(nodes[5].target == ttnn.mul)
+        self.assertTrue(nodes[5].args[0].target == ttnn.to_device)
+        self.assertTrue(nodes[5].args[0].args[0].target == ttnn.to_layout)
+        self.assertTrue(nodes[5].args[0].args[0].args[0].target == ttnn.from_torch)
+        self.assertTrue(nodes[6].target == ttnn.from_device)
+        self.assertTrue(nodes[7].target == ttnn.to_layout)
+        self.assertTrue(nodes[8].target == ttnn.to_torch)
+        # Check inference result
+        self.assertTrue(torch.allclose(result_before.to(torch.bfloat16), result_after))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_type_conversion.py
+++ b/tests/test_type_conversion.py
@@ -4,6 +4,7 @@ import unittest
 from torch_ttnn import ttnn
 import tt_lib
 
+
 class MulModule(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -14,10 +15,11 @@ class MulModule(torch.nn.Module):
     def input_shapes(self):
         return [(4, 4), (4, 4)]
 
+
 class TestModules(unittest.TestCase):
     def setUp(self):
         # Open device 0
-        self.device: ttnn.Device = ttnn.open_device(device_id = 0)
+        self.device: ttnn.Device = ttnn.open_device(device_id=0)
         # For AutoFormat
         tt_lib.device.SetDefaultDevice(self.device)
 
@@ -81,6 +83,7 @@ class TestModules(unittest.TestCase):
         self.assertTrue(nodes[8].target == ttnn.to_torch)
         # Check inference result
         self.assertTrue(torch.allclose(result_before.to(torch.bfloat16), result_after))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_type_conversion.py
+++ b/tests/test_type_conversion.py
@@ -4,8 +4,6 @@ import unittest
 from torch_ttnn import ttnn
 import tt_lib
 
-from tests.ttnn.utils_for_testing import check_with_pcc
-
 class MulModule(torch.nn.Module):
     def __init__(self):
         super().__init__()

--- a/tools/run_torchvision.py
+++ b/tools/run_torchvision.py
@@ -91,7 +91,11 @@ if __name__ == "__main__":
 
     models = ["dinov2_vits14", "alexnet", "googlenet", "resnet18", "vgg11"]
 
-    device = torch_ttnn.ttnn.open_device(device_id = 0) if args.backend == "torch_ttnn" else None
+    device = (
+        torch_ttnn.ttnn.open_device(device_id=0)
+        if args.backend == "torch_ttnn"
+        else None
+    )
     for m in models:
         try:
             run_model(

--- a/tools/run_torchvision.py
+++ b/tools/run_torchvision.py
@@ -91,7 +91,7 @@ if __name__ == "__main__":
 
     models = ["dinov2_vits14", "alexnet", "googlenet", "resnet18", "vgg11"]
 
-    device = torch_ttnn.ttnn.open(0) if args.backend == "torch_ttnn" else None
+    device = torch_ttnn.ttnn.open_device(device_id = 0) if args.backend == "torch_ttnn" else None
     for m in models:
         try:
             run_model(
@@ -106,4 +106,4 @@ if __name__ == "__main__":
         except:
             print(f"{m} FAIL")
     if args.backend == "torch_ttnn":
-        torch_ttnn.ttnn.close(device)
+        torch_ttnn.ttnn.close_device(device)

--- a/tools/run_transformers.py
+++ b/tools/run_transformers.py
@@ -19,6 +19,8 @@ class TestModel():
         self.model_name = model_name
         self.model_task = model_task
         self.test_input = test_input
+    def __repr__(self):
+        return self.model_name
 
 def run_model(model: str, backend: str, backward: bool, out_path: str, graphviz: bool, to_profile: bool, device = None):
 
@@ -135,6 +137,7 @@ def run_model(model: str, backend: str, backward: bool, out_path: str, graphviz:
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type = str, required = True)
     parser.add_argument("--out_path", "-o", type = str, default = os.path.join(os.getcwd(),"stat"))
     parser.add_argument("--backend", type = str)
     parser.add_argument("--graphviz", action="store_true")
@@ -194,9 +197,13 @@ if __name__ == "__main__":
             "http://images.cocodataset.org/val2017/000000039769.jpg"
         ),
     ]
+    def get_model(model_name):
+        for m in models:
+            if model_name == m.model_name:
+                return m
+        raise ValueError(f"model: {model_name} not supported. Supported models: {models}")
 
     device = torch_ttnn.ttnn.open_device(device_id = 0) if args.backend == "torch_ttnn" else None
-    for m in models:
-        run_model(m, args.backend, args.backward, args.out_path, args.graphviz, args.profile, device)
+    run_model(get_model(args.model), args.backend, args.backward, args.out_path, args.graphviz, args.profile, device)
     if args.backend == "torch_ttnn":
         torch_ttnn.ttnn.close_device(device)

--- a/tools/run_transformers.py
+++ b/tools/run_transformers.py
@@ -34,7 +34,6 @@ def run_model(
     to_profile: bool,
     device=None,
 ):
-
     text_modules = [
         AutoModelForQuestionAnswering,
         AutoModelForCausalLM,

--- a/tools/run_transformers.py
+++ b/tools/run_transformers.py
@@ -12,7 +12,7 @@ class TestModel():
 
 def run_model(model: str, backend: str, backward: bool, out_path: str, graphviz: bool, to_profile: bool, device = None):
 
-    tokenizer = AutoTokenizer.from_pretrained(model.model_name)
+    tokenizer = AutoTokenizer.from_pretrained(model.model_name, padding_side="left")
     m = model.model_task.from_pretrained(model.model_name)
 
     if backward:
@@ -37,7 +37,7 @@ def run_model(model: str, backend: str, backward: bool, out_path: str, graphviz:
     if model.model_task == AutoModelForQuestionAnswering:
         inputs = tokenizer.encode_plus(model.test_input["question"], model.test_input["context"], add_special_tokens=True, return_tensors="pt")
     elif model.model_task == AutoModelForCausalLM:
-        inputs = tokenizer.encode_plus(model.test_input, add_special_tokens=True, return_tensors="pt")
+        inputs = tokenizer(model.test_input, return_tensors="pt")
     else:
         raise ValueError(f"model task: {model.model_task} not supported.")
 
@@ -49,15 +49,10 @@ def run_model(model: str, backend: str, backward: bool, out_path: str, graphviz:
         if torch.cuda.is_available():
             activities.append(ProfilerActivity.CUDA)
         with profile(activities=activities, record_shapes=True) as prof:
-            # with torch.no_grad():
-            #     results = m(**inputs)
+            with torch.no_grad():
+                results = m(**inputs)
             # if backward:
             #     result.backward(torch.ones_like(result))
-            if model.model_task == AutoModelForQuestionAnswering:
-                results = m(**inputs)
-            elif model.model_task == AutoModelForCausalLM:
-                # results = m.generate(**inputs, do_sample=True, max_length=30)
-                results = m(**inputs)
         prof.export_chrome_trace(trace_file)
     else:
         with torch.no_grad():
@@ -69,14 +64,15 @@ def run_model(model: str, backend: str, backward: bool, out_path: str, graphviz:
         response_start = torch.argmax(results.start_logits)
         response_end = torch.argmax(results.end_logits) + 1
         response_tokens = inputs.input_ids[0, response_start:response_end]
-        response = tokenizer.decode(response_tokens)
+        output = tokenizer.decode(response_tokens)
     elif model.model_task == AutoModelForCausalLM:
-        response = ""
-        # response = tokenizer.batch_decode(results, skip_special_tokens=True)
+        next_token_logits = results.logits[:, -1]
+        next_token = next_token_logits.softmax(dim=-1).argmax()
+        output = tokenizer.decode([next_token])
     else:
         raise ValueError(f"model task: {model.model_task} not supported.")
 
-    print(response)
+    print(f"model_name: {model.model_name}\ninput: {model.test_input}\noutput: {output}")
 
 
 if __name__ == "__main__":
@@ -97,24 +93,31 @@ if __name__ == "__main__":
         from torch_ttnn import torch_stat
 
     models = [
-        # TestModel(
-        #     "phiyodr/bert-large-finetuned-squad2",
-        #     AutoModelForQuestionAnswering,
-        #     {'question': 'What discipline did Winkelmann create?',
-        #      'context': 'Johann Joachim Winckelmann was a German art historian and archaeologist. He was a pioneering Hellenist who first articulated the difference between Greek, Greco-Roman and Roman art. "The prophet and founding hero of modern archaeology", Winckelmann was one of the founders of scientific archaeology and first applied the categories of style on a large, systematic basis to the history of art. '}
-        # ),
+        TestModel(
+            "phiyodr/bert-large-finetuned-squad2",
+            AutoModelForQuestionAnswering,
+            {'question': 'What discipline did Winkelmann create?',
+             'context': 'Johann Joachim Winckelmann was a German art historian and archaeologist. He was a pioneering Hellenist who first articulated the difference between Greek, Greco-Roman and Roman art. "The prophet and founding hero of modern archaeology", Winckelmann was one of the founders of scientific archaeology and first applied the categories of style on a large, systematic basis to the history of art. '}
+        ),
         TestModel(
             "tiiuae/falcon-7b-instruct",
             AutoModelForCausalLM,
             "Once upon a time"
+        ),
+        TestModel(
+            "mistralai/Mistral-7B-Instruct-v0.2",
+            AutoModelForCausalLM,
+            "My name is Johnny Appleseed, and today I"
+        ),
+        TestModel(
+            "bigscience/bloom-1b1",
+            AutoModelForCausalLM,
+            "My cat and my dog"
         )
     ]
 
     device = torch_ttnn.ttnn.open_device(device_id = 0) if args.backend == "torch_ttnn" else None
     for m in models:
-        try:
-            run_model(m, args.backend, args.backward, args.out_path, args.graphviz, args.profile, device)
-        except:
-            print(f"{m} FAIL")
+        run_model(m, args.backend, args.backward, args.out_path, args.graphviz, args.profile, device)
     if args.backend == "torch_ttnn":
         torch_ttnn.ttnn.close_device(device)

--- a/tools/run_transformers.py
+++ b/tools/run_transformers.py
@@ -14,20 +14,31 @@ from transformers import (
     AutoModelForObjectDetection,
 )
 
-class TestModel():
+
+class TestModel:
     def __init__(self, model_name, model_task, test_input):
         self.model_name = model_name
         self.model_task = model_task
         self.test_input = test_input
+
     def __repr__(self):
         return self.model_name
 
-def run_model(model: str, backend: str, backward: bool, out_path: str, graphviz: bool, to_profile: bool, device = None):
+
+def run_model(
+    model: str,
+    backend: str,
+    backward: bool,
+    out_path: str,
+    graphviz: bool,
+    to_profile: bool,
+    device=None,
+):
 
     text_modules = [
         AutoModelForQuestionAnswering,
         AutoModelForCausalLM,
-        AutoModelForSequenceClassification
+        AutoModelForSequenceClassification,
     ]
     vision_modules = [
         AutoModelForObjectDetection,
@@ -55,11 +66,15 @@ def run_model(model: str, backend: str, backward: bool, out_path: str, graphviz:
         option = torch_ttnn.TorchTtnnOption(device=device)
         m = torch.compile(m, backend=torch_ttnn.backend, options=option)
     elif backend == "torch_stat":
-        option = torch_stat.TorchStatOption(model_name = model.model_name, backward = backward,
-                                            out = out_path, gen_graphviz=graphviz)
+        option = torch_stat.TorchStatOption(
+            model_name=model.model_name,
+            backward=backward,
+            out=out_path,
+            gen_graphviz=graphviz,
+        )
         m = torch.compile(m, backend=torch_stat.backend(option))
     else:
-        assert(0 and "Unsupport backend")
+        assert 0 and "Unsupport backend"
 
     if model.model_task == AutoModelForQuestionAnswering:
         inputs = tokenizer.encode_plus(
@@ -69,11 +84,11 @@ def run_model(model: str, backend: str, backward: bool, out_path: str, graphviz:
             return_tensors="pt",
             max_length=256,
             padding="max_length",
-            truncation=True
+            truncation=True,
         )
     elif (
-        model.model_task == AutoModelForCausalLM or 
-        model.model_task == AutoModelForSequenceClassification
+        model.model_task == AutoModelForCausalLM
+        or model.model_task == AutoModelForSequenceClassification
     ):
         inputs = tokenizer(model.test_input, return_tensors="pt")
     elif model.model_task == AutoModelForObjectDetection:
@@ -84,6 +99,7 @@ def run_model(model: str, backend: str, backward: bool, out_path: str, graphviz:
 
     if to_profile:
         from torch.profiler import profile, record_function, ProfilerActivity
+
         trace_file = os.path.join(out_path, "profile", model.model_name)
         os.makedirs(os.path.dirname(trace_file), exist_ok=True)
         activities = [ProfilerActivity.CPU]
@@ -118,14 +134,20 @@ def run_model(model: str, backend: str, backward: bool, out_path: str, graphviz:
         result = normalized.argmax().item()
     elif model.model_task == AutoModelForObjectDetection:
         target_sizes = torch.tensor([image.size[::-1]])
-        results = image_processor.post_process_object_detection(outputs, threshold=0.9, target_sizes=target_sizes)[0]
+        results = image_processor.post_process_object_detection(
+            outputs, threshold=0.9, target_sizes=target_sizes
+        )[0]
     else:
         raise ValueError(f"model task: {model.model_task} not supported.")
 
     if model.model_task in text_modules:
-        print(f"model_name: {model.model_name}\ninput: {model.test_input}\nresult: {result}")
+        print(
+            f"model_name: {model.model_name}\ninput: {model.test_input}\nresult: {result}"
+        )
     elif model.model_task in vision_modules:
-        for score, label, box in zip(results["scores"], results["labels"], results["boxes"]):
+        for score, label, box in zip(
+            results["scores"], results["labels"], results["boxes"]
+        ):
             box = [round(i, 2) for i in box.tolist()]
             print(
                 f"Detected {m.config.id2label[label.item()]} with confidence "
@@ -137,16 +159,18 @@ def run_model(model: str, backend: str, backward: bool, out_path: str, graphviz:
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--model", type = str, required = True)
-    parser.add_argument("--out_path", "-o", type = str, default = os.path.join(os.getcwd(),"stat"))
-    parser.add_argument("--backend", type = str)
+    parser.add_argument("--model", type=str, required=True)
+    parser.add_argument(
+        "--out_path", "-o", type=str, default=os.path.join(os.getcwd(), "stat")
+    )
+    parser.add_argument("--backend", type=str)
     parser.add_argument("--graphviz", action="store_true")
     parser.add_argument("--backward", action="store_true")
     parser.add_argument("--profile", action="store_true")
     args = parser.parse_args()
-    assert(args.backend in ["torch_ttnn", "torch_stat"])
+    assert args.backend in ["torch_ttnn", "torch_stat"]
     if args.backend == "torch_ttnn" and args.backward:
-        assert(0 and "torch_ttnn not yet support backward")
+        assert 0 and "torch_ttnn not yet support backward"
 
     if args.backend == "torch_ttnn":
         import torch_ttnn
@@ -157,53 +181,60 @@ if __name__ == "__main__":
         TestModel(
             "phiyodr/bert-large-finetuned-squad2",
             AutoModelForQuestionAnswering,
-            {'question': 'What discipline did Winkelmann create?',
-             'context': 'Johann Joachim Winckelmann was a German art historian and archaeologist. He was a pioneering Hellenist who first articulated the difference between Greek, Greco-Roman and Roman art. "The prophet and founding hero of modern archaeology", Winckelmann was one of the founders of scientific archaeology and first applied the categories of style on a large, systematic basis to the history of art. '}
+            {
+                "question": "What discipline did Winkelmann create?",
+                "context": 'Johann Joachim Winckelmann was a German art historian and archaeologist. He was a pioneering Hellenist who first articulated the difference between Greek, Greco-Roman and Roman art. "The prophet and founding hero of modern archaeology", Winckelmann was one of the founders of scientific archaeology and first applied the categories of style on a large, systematic basis to the history of art. ',
+            },
         ),
         TestModel(
-            "tiiuae/falcon-7b-instruct",
-            AutoModelForCausalLM,
-            "Once upon a time"
+            "tiiuae/falcon-7b-instruct", AutoModelForCausalLM, "Once upon a time"
         ),
         TestModel(
             "mistralai/Mistral-7B-Instruct-v0.2",
             AutoModelForCausalLM,
-            "My name is Johnny Appleseed, and today I"
+            "My name is Johnny Appleseed, and today I",
         ),
-        TestModel(
-            "bigscience/bloom-1b1",
-            AutoModelForCausalLM,
-            "My cat and my dog"
-        ),
+        TestModel("bigscience/bloom-1b1", AutoModelForCausalLM, "My cat and my dog"),
         # Need torch 2.3.0+
         TestModel(
-            "state-spaces/mamba-130m-hf",
-            AutoModelForCausalLM,
-            "Hey how are you doing?"
+            "state-spaces/mamba-130m-hf", AutoModelForCausalLM, "Hey how are you doing?"
         ),
         TestModel(
-            "huggyllama/llama-7b",
-            AutoModelForCausalLM,
-            "Spring is a good time to"
+            "huggyllama/llama-7b", AutoModelForCausalLM, "Spring is a good time to"
         ),
         TestModel(
             "mnoukhov/gpt2-imdb-sentiment-classifier",
             AutoModelForSequenceClassification,
-            'This is the kind of movie you put in the background while working on other things.'
+            "This is the kind of movie you put in the background while working on other things.",
         ),
         TestModel(
             "hustvl/yolos-tiny",
             AutoModelForObjectDetection,
-            "http://images.cocodataset.org/val2017/000000039769.jpg"
+            "http://images.cocodataset.org/val2017/000000039769.jpg",
         ),
     ]
+
     def get_model(model_name):
         for m in models:
             if model_name == m.model_name:
                 return m
-        raise ValueError(f"model: {model_name} not supported. Supported models: {models}")
+        raise ValueError(
+            f"model: {model_name} not supported. Supported models: {models}"
+        )
 
-    device = torch_ttnn.ttnn.open_device(device_id = 0) if args.backend == "torch_ttnn" else None
-    run_model(get_model(args.model), args.backend, args.backward, args.out_path, args.graphviz, args.profile, device)
+    device = (
+        torch_ttnn.ttnn.open_device(device_id=0)
+        if args.backend == "torch_ttnn"
+        else None
+    )
+    run_model(
+        get_model(args.model),
+        args.backend,
+        args.backward,
+        args.out_path,
+        args.graphviz,
+        args.profile,
+        device,
+    )
     if args.backend == "torch_ttnn":
         torch_ttnn.ttnn.close_device(device)

--- a/tools/run_transformers.py
+++ b/tools/run_transformers.py
@@ -1,0 +1,120 @@
+import os
+import argparse
+import torch
+# Load model directly
+from transformers import AutoTokenizer, AutoModelForQuestionAnswering, AutoModelForCausalLM
+
+class TestModel():
+    def __init__(self, model_name, model_task, test_input):
+        self.model_name = model_name
+        self.model_task = model_task
+        self.test_input = test_input
+
+def run_model(model: str, backend: str, backward: bool, out_path: str, graphviz: bool, to_profile: bool, device = None):
+
+    tokenizer = AutoTokenizer.from_pretrained(model.model_name)
+    m = model.model_task.from_pretrained(model.model_name)
+
+    if backward:
+        try:
+            m.train()
+        except:
+            print(f"{model.model_name} Cannot to the training mode, use just eval mode")
+            m.eval()
+            backward = False
+    else:
+        m.eval()
+    if backend == "torch_ttnn":
+        option = torch_ttnn.TorchTtnnOption(device=device)
+        m = torch.compile(m, backend=torch_ttnn.backend(option))
+    elif backend == "torch_stat":
+        option = torch_stat.TorchStatOption(model_name = model.model_name, backward = backward,
+                                            out = out_path, gen_graphviz=graphviz)
+        m = torch.compile(m, backend=torch_stat.backend(option))
+    else:
+        assert(0 and "Unsupport backend")
+
+    if model.model_task == AutoModelForQuestionAnswering:
+        inputs = tokenizer.encode_plus(model.test_input["question"], model.test_input["context"], add_special_tokens=True, return_tensors="pt")
+    elif model.model_task == AutoModelForCausalLM:
+        inputs = tokenizer.encode_plus(model.test_input, add_special_tokens=True, return_tensors="pt")
+    else:
+        raise ValueError(f"model task: {model.model_task} not supported.")
+
+    if to_profile:
+        from torch.profiler import profile, record_function, ProfilerActivity
+        trace_file = os.path.join(out_path, "profile", model.model_name)
+        os.makedirs(os.path.dirname(trace_file), exist_ok=True)
+        activities = [ProfilerActivity.CPU]
+        if torch.cuda.is_available():
+            activities.append(ProfilerActivity.CUDA)
+        with profile(activities=activities, record_shapes=True) as prof:
+            # with torch.no_grad():
+            #     results = m(**inputs)
+            # if backward:
+            #     result.backward(torch.ones_like(result))
+            if model.model_task == AutoModelForQuestionAnswering:
+                results = m(**inputs)
+            elif model.model_task == AutoModelForCausalLM:
+                # results = m.generate(**inputs, do_sample=True, max_length=30)
+                results = m(**inputs)
+        prof.export_chrome_trace(trace_file)
+    else:
+        with torch.no_grad():
+            results = m(**inputs)
+        # if backward:
+        #     result.backward(torch.ones_like(result))
+
+    if model.model_task == AutoModelForQuestionAnswering:
+        response_start = torch.argmax(results.start_logits)
+        response_end = torch.argmax(results.end_logits) + 1
+        response_tokens = inputs.input_ids[0, response_start:response_end]
+        response = tokenizer.decode(response_tokens)
+    elif model.model_task == AutoModelForCausalLM:
+        response = ""
+        # response = tokenizer.batch_decode(results, skip_special_tokens=True)
+    else:
+        raise ValueError(f"model task: {model.model_task} not supported.")
+
+    print(response)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out_path", "-o", type = str, default = os.path.join(os.getcwd(),"stat"))
+    parser.add_argument("--backend", type = str)
+    parser.add_argument("--graphviz", action="store_true")
+    parser.add_argument("--backward", action="store_true")
+    parser.add_argument("--profile", action="store_true")
+    args = parser.parse_args()
+    assert(args.backend in ["torch_ttnn", "torch_stat"])
+    if args.backend == "torch_ttnn" and args.backward:
+        assert(0 and "torch_ttnn not yet support backward")
+
+    if args.backend == "torch_ttnn":
+        import torch_ttnn
+    elif args.backend == "torch_stat":
+        from torch_ttnn import torch_stat
+
+    models = [
+        # TestModel(
+        #     "phiyodr/bert-large-finetuned-squad2",
+        #     AutoModelForQuestionAnswering,
+        #     {'question': 'What discipline did Winkelmann create?',
+        #      'context': 'Johann Joachim Winckelmann was a German art historian and archaeologist. He was a pioneering Hellenist who first articulated the difference between Greek, Greco-Roman and Roman art. "The prophet and founding hero of modern archaeology", Winckelmann was one of the founders of scientific archaeology and first applied the categories of style on a large, systematic basis to the history of art. '}
+        # ),
+        TestModel(
+            "tiiuae/falcon-7b-instruct",
+            AutoModelForCausalLM,
+            "Once upon a time"
+        )
+    ]
+
+    device = torch_ttnn.ttnn.open_device(device_id = 0) if args.backend == "torch_ttnn" else None
+    for m in models:
+        try:
+            run_model(m, args.backend, args.backward, args.out_path, args.graphviz, args.profile, device)
+        except:
+            print(f"{m} FAIL")
+    if args.backend == "torch_ttnn":
+        torch_ttnn.ttnn.close_device(device)

--- a/torch_ttnn/backend.py
+++ b/torch_ttnn/backend.py
@@ -2,6 +2,7 @@ import torch.linalg
 import torch
 from typing import List
 import torch._dynamo
+from functorch.compile import make_boxed_func
 
 torch._dynamo.config.suppress_errors = False
 torch._dynamo.config.verbose = True
@@ -30,6 +31,9 @@ def aten_backend(
     torch.fx.graph._register_custom_builtin("ttnn_Specified_Device", "", option.device)
     torch.fx.graph._register_custom_builtin(
         "ttnn_ROW_MAJOR_LAYOUT", "", ttnn.ROW_MAJOR_LAYOUT
+    )
+    torch.fx.graph._register_custom_builtin(
+        "ttnn_TILE_LAYOUT", "", ttnn.TILE_LAYOUT
     )
 
     # Rewrite with ttnn ops, will insert redundant data movement
@@ -70,7 +74,7 @@ def aten_backend(
     gm.graph.print_tabular()
     print(gm.code)
     option._out_fx_graphs.append(gm.graph)
-    return gm
+    return make_boxed_func(gm)
 
 
 from torch._dynamo.backends.common import aot_autograd

--- a/torch_ttnn/backend.py
+++ b/torch_ttnn/backend.py
@@ -42,6 +42,15 @@ def aten_backend(
     torch.fx.graph._register_custom_builtin("ttnn_uint32", "", ttnn.uint32)
     torch.fx.graph._register_custom_builtin("ttnn_bfloat16", "", ttnn.bfloat16)
 
+    # Some ttnn objects are unhashable because they are function calls.
+    # However, arguments for these functions are usually hashable.
+    import tt_lib as ttl
+    # ttnn.DRAM_MEMORY_CONFIG = ttnn.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.DRAM)
+    torch.fx.graph._register_custom_builtin("ttl_tensor_TensorMemoryLayout_INTERLEAVED", "", ttl.tensor.TensorMemoryLayout.INTERLEAVED)
+    torch.fx.graph._register_custom_builtin("ttl_tensor_BufferType_DRAM", "", ttl.tensor.BufferType.DRAM)
+    # ttnn.L1_MEMORY_CONFIG = ttnn.MemoryConfig(ttl.tensor.TensorMemoryLayout.INTERLEAVED, ttl.tensor.BufferType.L1)
+    torch.fx.graph._register_custom_builtin("ttl_tensor_BufferType_L1", "", ttl.tensor.BufferType.L1)
+
     # Rewrite with ttnn ops, will insert redundant data movement
     from torch.fx.passes.infra.pass_manager import PassManager
     from torch.fx.passes.dialect.common.cse_pass import CSEPass

--- a/torch_ttnn/backend.py
+++ b/torch_ttnn/backend.py
@@ -39,6 +39,8 @@ def aten_backend(
     torch.fx.graph._register_custom_builtin(
         "ttnn_TILE_LAYOUT", "", ttnn.TILE_LAYOUT
     )
+    torch.fx.graph._register_custom_builtin("ttnn_uint32", "", ttnn.uint32)
+    torch.fx.graph._register_custom_builtin("ttnn_bfloat16", "", ttnn.bfloat16)
 
     # Rewrite with ttnn ops, will insert redundant data movement
     from torch.fx.passes.infra.pass_manager import PassManager

--- a/torch_ttnn/backend.py
+++ b/torch_ttnn/backend.py
@@ -31,6 +31,11 @@ def aten_backend(
     from .handle_input_aliasing import remove_clones_for_input_aliasing
     gm = remove_clones_for_input_aliasing(gm)
 
+    # Change float types in dtype kwargs to bfloat16
+    from .convert_type import convert_dtype_to_bfloat16, convert_float_to_bfloat16
+    gm = convert_float_to_bfloat16(gm)
+    gm = convert_dtype_to_bfloat16(gm)
+
     option: TorchTtnnOption = options["torch_ttnn_option"]
     torch.fx.graph._register_custom_builtin("ttnn_Specified_Device", "", option.device)
     torch.fx.graph._register_custom_builtin(

--- a/torch_ttnn/convert_type.py
+++ b/torch_ttnn/convert_type.py
@@ -1,0 +1,62 @@
+import math
+import torch
+from typing import List
+from .utils import GraphCleanup
+
+# torch.fx defines a placeholder node as a function input
+def get_input_nodes(gm: torch.fx.GraphModule) -> List[torch.fx.Node]:
+    input_nodes = [node for node in gm.graph.nodes if (node.op == "placeholder")]
+    return input_nodes
+
+pytorch_float_types = [
+    torch.float32,
+    torch.float64,
+    torch.float16,
+]
+
+def convert_float_to_bfloat16(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
+    input_nodes = get_input_nodes(gm)
+    modified = False
+
+    for node in input_nodes:
+        arg_metadata = node.meta["val"]
+        if arg_metadata.dtype in pytorch_float_types:
+            with gm.graph.inserting_after(input_nodes[-1]):
+                to = gm.graph.call_method("to", args=(node, torch.bfloat16))
+                node.replace_all_uses_with(to, delete_user_cb=lambda node: node != to,)
+                modified = True
+
+    if modified:
+        gm = GraphCleanup(gm)
+    return gm
+
+# Use on aten level
+def convert_dtype_to_bfloat16(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
+    modified = False
+    for node in gm.graph.nodes:
+        # Convert min, max, of float32 to float16
+        # TODO(kevinwuTT): Optimize this without needing to process every arg?
+        new_args = []
+        for arg in node.args:
+            if type(arg) == int or type(arg) == float:
+                if arg == torch.finfo(torch.float32).min:
+                    new_args.append(torch.finfo(torch.bfloat16).min)
+                elif arg == torch.finfo(torch.float32).max:
+                    new_args.append(torch.finfo(torch.bfloat16).max)
+                else:
+                    new_args.append(arg)
+            else:
+                new_args.append(arg)
+        node.args = tuple(new_args)
+
+        if node.target == torch.ops.aten._to_copy.default:
+            new_kwargs = {"dtype": torch.bfloat16}
+            node.kwargs = new_kwargs
+        if node.target == torch.ops.aten.full.default:
+            new_kwargs = node.kwargs.copy()
+            new_kwargs["dtype"] = torch.bfloat16
+            node.kwargs = new_kwargs
+
+    gm = GraphCleanup(gm)
+
+    return gm

--- a/torch_ttnn/handle_input_aliasing.py
+++ b/torch_ttnn/handle_input_aliasing.py
@@ -1,0 +1,83 @@
+import torch
+from typing import List
+
+"""
+AOT Autograd has an optimization where if it determines that the storage of the
+output is the same as the input, it will return data from the input. The output
+is checked if it's an alias of the input. This becomes problematic when we
+have data transfer between host and device. The issue has been raised before.
+See: https://github.com/pytorch/pytorch/issues/108079
+
+One workaround is to insert a clone op after every input node before the graph
+is completely lowered to aten ops. This can be accomplished by pointing the
+entry function with a `torch.fx.GraphModule` parameter to the `backend`
+positional argument for `torch.compile`. At this point, the graph will have
+higher-level torch ops where clone ops can be inserted. Then define another
+function that will be passed to the `fw_compiler/bw_compiler` parameter for
+`aot_autograd`. This is when the input aliasing metadata will be determined
+and the graph will be lowered to aten ops. After this, the clone ops can
+be removed with another pass.
+
+The method is inspired by TensorRT:
+https://github.com/pytorch/TensorRT/commit/7daa1120dc1bc72d6f92f1e7aa2b357a65b6ea08
+"""
+
+# torch.fx defines a placeholder node as a function input
+def get_input_nodes(gm: torch.fx.GraphModule) -> List[torch.fx.Node]:
+    input_nodes = [node for node in gm.graph.nodes if (node.op == "placeholder")]
+    return input_nodes
+
+def clean_up_graph(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
+    gm.graph.eliminate_dead_code()
+    gm.graph.lint()
+    gm.recompile()
+
+    return gm
+
+# Insert aten.clone nodes after every input to prevent input aliasing
+def insert_clones_for_input_aliasing(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
+    input_nodes = get_input_nodes(gm)
+    modified = False
+    for node in input_nodes:
+        """TODO(kevinwuTT): This does not work if inserting right after the node itself.
+        Only works if inserting after all of the input_nodes.
+        TypeError: forward() missing `n` required positional arguments
+        Somehow the argument list will get truncated.
+        """
+        with gm.graph.inserting_after(input_nodes[-1]):
+            clone_node = gm.graph.call_function(
+                torch.ops.aten.clone.default, args=(node,))
+            node.replace_all_uses_with(clone_node, delete_user_cb=lambda node: node != clone_node,)
+            modified = True
+
+    if modified:
+        gm = clean_up_graph(gm)
+
+    return gm
+
+
+def remove_clones_for_input_aliasing(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
+    """ Remove the clone ops inserted to handle input aliasing
+    opcode         name             target               args                                                                           
+    -------------  ---------------  -------------------  ------------
+    placeholder    l_input_         L_input_             ()   
+    call_function  clone_default    aten.clone.default   (l_input_,)
+    call_function  op               <op_func>            (clone_default)
+    """
+    modified = False
+    for node in gm.graph.nodes:
+        if (
+            node.op == "placeholder"
+            and len(node.users) == 1
+            and list(node.users)[0].target == torch.ops.aten.clone.default
+        ):
+            clone_node = list(node.users)[0]
+            clone_node.replace_all_uses_with(node)
+            gm.graph.erase_node(clone_node)
+
+            modified = True
+
+    if modified:
+        gm = clean_up_graph(gm)
+
+    return gm

--- a/torch_ttnn/mock_ttnn.py
+++ b/torch_ttnn/mock_ttnn.py
@@ -22,12 +22,12 @@ class Device:
     #      return f"Device({self.device_id})"
 
 
-def open(device_id):
+def open_device(device_id):
     print(f"Device {device_id} is opened")
     return Device(device_id)
 
 
-def close(device):
+def close_device(device):
     print(f"Device {device.device_id} is closed")
     pass
 
@@ -109,6 +109,7 @@ def permute(x, order):
 
 
 ROW_MAJOR_LAYOUT = 0
+TILE_LAYOUT = 1
 
 # Wrap the functions so that they can be used in torch.fx
 # and block the further recusive tracing. See:

--- a/torch_ttnn/passes/add_data_move_pass.py
+++ b/torch_ttnn/passes/add_data_move_pass.py
@@ -1,4 +1,10 @@
 import torch
+from ..utils import (
+    DummyTtnnUint32,
+    DummyTtnnRowMajorLayout,
+    DummyTtnnTileLayout,
+    DummyDevice,
+)
 
 try:
     import ttnn
@@ -148,26 +154,6 @@ def try_add_data_move_out_for_split(src_node, dst_idx, dst_node) -> torch.fx.nod
     else:
         return None
 
-# See https://docs.google.com/document/d/1r2D4AagoeTRjEmXFnWzzafaWQkf-8hlIbX2ze-JAUFo/edit#heading=h.zad9rwqjv6cr
-class DummyDevice:
-    def __repr__(self):
-        return f"ttnn_Specified_Device"
-
-class DummyTtnnRowMajorLayout:
-    def __repr__(self):
-        return f"ttnn_ROW_MAJOR_LAYOUT"
-
-class DummyTtnnTileLayout:
-    def __repr__(self):
-        return f"ttnn_TILE_LAYOUT"
-
-class DummyTtnnUint32:
-    def __repr__(self):
-        return f"ttnn_uint32"
-
-class DummyTtnnBfloat16:
-    def __repr__(self):
-        return f"ttnn_bfloat16"
 
 class AddDataMovePass(PassBase):
     def call(self, gm: torch.fx.GraphModule):

--- a/torch_ttnn/passes/add_data_move_pass.py
+++ b/torch_ttnn/passes/add_data_move_pass.py
@@ -146,10 +146,7 @@ def try_add_data_move_in_kwargs(src_node_kwarg, dst_node, device) -> torch.fx.no
     return new_nodes[-1]
 
 def try_add_data_move_in(src_node, dst_idx, dst_node, device) -> torch.fx.node.Node:
-    print(f"src_node: {src_node}, dst_node: {dst_node}")
-
     if not should_add_data_move_in(src_node, dst_node):
-        print("skip should_add_data_move_in")
         return None
 
     g = dst_node.graph

--- a/torch_ttnn/passes/add_data_move_pass.py
+++ b/torch_ttnn/passes/add_data_move_pass.py
@@ -62,6 +62,7 @@ def is_tt_compute(node) -> bool:
             ttnn.global_avg_pool2d,
             ttnn.clip,
             ttnn.squeeze,
+            ttnn.full,
         ]
     )
 
@@ -143,7 +144,10 @@ def try_add_data_move_in_kwargs(src_node_kwarg, dst_node, device) -> torch.fx.no
     return new_nodes[-1]
 
 def try_add_data_move_in(src_node, dst_idx, dst_node, device) -> torch.fx.node.Node:
+    print(f"src_node: {src_node}, dst_node: {dst_node}")
+
     if not should_add_data_move_in(src_node, dst_node):
+        print("skip should_add_data_move_in")
         return None
 
     g = dst_node.graph

--- a/torch_ttnn/passes/add_data_move_pass.py
+++ b/torch_ttnn/passes/add_data_move_pass.py
@@ -64,6 +64,7 @@ def is_tt_compute(node) -> bool:
             ttnn.full,
             ttnn.lt,
             ttnn.cos,
+            ttnn.sigmoid,
         ]
     )
 

--- a/torch_ttnn/passes/add_data_move_pass.py
+++ b/torch_ttnn/passes/add_data_move_pass.py
@@ -41,6 +41,7 @@ def is_tt_compute(node) -> bool:
             ttnn.gelu,
             ttnn.embedding,
             ttnn.split,
+            ttnn.clone,
         ]
     )
 
@@ -53,6 +54,7 @@ def is_tt_data_move(node) -> bool:
         ttnn.to_device,
         ttnn.from_torch,
         ttnn.to_torch,
+        ttnn.MemoryConfig
     ]
 
 
@@ -67,7 +69,7 @@ def is_reshape_rank_4(node):
         return False
 
 def should_add_data_move_in(src_node, dst_node) -> bool:
-    if isinstance(src_node, (int, float, list, tuple)):
+    if isinstance(src_node, (int, float, list, tuple)) or not isinstance(src_node, torch.fx.node.Node):
         return False
     return is_tt_compute(dst_node) and not is_tt(src_node)
 

--- a/torch_ttnn/passes/add_data_move_pass.py
+++ b/torch_ttnn/passes/add_data_move_pass.py
@@ -63,6 +63,7 @@ def is_tt_compute(node) -> bool:
             ttnn.clip,
             ttnn.squeeze,
             ttnn.full,
+            ttnn.lt,
         ]
     )
 

--- a/torch_ttnn/passes/add_data_move_pass.py
+++ b/torch_ttnn/passes/add_data_move_pass.py
@@ -31,6 +31,8 @@ def is_tt_compute(node) -> bool:
             ttnn.reshape,
             ttnn.permute,
             ttnn.relu,
+            ttnn.reciprocal,
+            ttnn.gelu,
         ]
     )
 

--- a/torch_ttnn/passes/add_data_move_pass.py
+++ b/torch_ttnn/passes/add_data_move_pass.py
@@ -64,6 +64,7 @@ def is_tt_compute(node) -> bool:
             ttnn.squeeze,
             ttnn.full,
             ttnn.lt,
+            ttnn.cos,
         ]
     )
 

--- a/torch_ttnn/passes/add_data_move_pass.py
+++ b/torch_ttnn/passes/add_data_move_pass.py
@@ -30,6 +30,7 @@ def is_tt_compute(node) -> bool:
             ttnn.tanh,
             ttnn.reshape,
             ttnn.permute,
+            ttnn.relu,
         ]
     )
 

--- a/torch_ttnn/passes/add_data_move_pass.py
+++ b/torch_ttnn/passes/add_data_move_pass.py
@@ -43,6 +43,9 @@ def is_tt_compute(node) -> bool:
             ttnn.split,
             ttnn.clone,
             ttnn.layer_norm,
+            ttnn.neg,
+            ttnn.ones,
+            ttnn.tril,
         ]
     )
 

--- a/torch_ttnn/passes/add_data_move_pass.py
+++ b/torch_ttnn/passes/add_data_move_pass.py
@@ -155,10 +155,7 @@ def try_add_data_move_in(src_node, dst_idx, dst_node, device) -> torch.fx.node.N
     g = dst_node.graph
     new_nodes = list()
     with g.inserting_before(dst_node):
-        if dst_node.target == ttnn.embedding and dst_idx == 0:
-            new_nodes.append(g.call_function(ttnn.from_torch, (src_node, DummyTtnnUint32())))
-        else:
-            new_nodes.append(g.call_function(ttnn.from_torch, (src_node, )))
+        new_nodes.append(g.call_function(ttnn.from_torch, (src_node, )))
         if dst_node.target != ttnn.reshape and dst_node.target != ttnn.embedding and dst_node.target != ttnn.zeros_like:
             new_nodes.append(g.call_function(
                 ttnn.to_layout, (new_nodes[-1], DummyTtnnTileLayout())

--- a/torch_ttnn/passes/add_data_move_pass.py
+++ b/torch_ttnn/passes/add_data_move_pass.py
@@ -56,6 +56,12 @@ def is_tt_compute(node) -> bool:
             ttnn.logical_not,
             ttnn.zeros_like,
             ttnn.mean,
+            ttnn.pow,
+            ttnn.rsqrt,
+            ttnn.silu,
+            ttnn.global_avg_pool2d,
+            ttnn.clip,
+            ttnn.squeeze,
         ]
     )
 

--- a/torch_ttnn/passes/to_tt_pass.py
+++ b/torch_ttnn/passes/to_tt_pass.py
@@ -41,6 +41,8 @@ class ReplaceMoreTt(torch.fx.Transformer):
             return super().call_function(ttnn.gelu, args, kwargs)
         elif target == torch.ops.aten.embedding.default:
             return super().call_function(ttnn.embedding, (args[1], args[0]), kwargs)
+        elif target == torch.ops.aten.split.Tensor:
+            return super().call_function(ttnn.split, args, kwargs)
         return super().call_function(target, args, kwargs)
 
 

--- a/torch_ttnn/passes/to_tt_pass.py
+++ b/torch_ttnn/passes/to_tt_pass.py
@@ -105,6 +105,7 @@ class ReplaceMoreTt(torch.fx.Transformer):
 def torch_dtype_to_dummy_ttnn_dtype(dtype: torch.dtype):
     # Add newly supported dtypes here:
     dtype_map = {
+        torch.float32 : DummyTtnnBfloat16(),
         torch.bfloat16 : DummyTtnnBfloat16()
     }
     if dtype in dtype_map:

--- a/torch_ttnn/passes/to_tt_pass.py
+++ b/torch_ttnn/passes/to_tt_pass.py
@@ -91,6 +91,8 @@ class ReplaceMoreTt(torch.fx.Transformer):
             call_func =  super().call_function(ttnn.lt, args, kwargs)
         elif target == torch.ops.aten.cos.default:
             call_func =  super().call_function(ttnn.cos, args, kwargs)
+        elif target == torch.ops.aten.sigmoid.default:
+            call_func =  super().call_function(ttnn.sigmoid, args, kwargs)
         else:
             call_func = super().call_function(target, args, kwargs)
 

--- a/torch_ttnn/passes/to_tt_pass.py
+++ b/torch_ttnn/passes/to_tt_pass.py
@@ -85,7 +85,11 @@ class ReplaceMoreTt(torch.fx.Transformer):
         elif target == torch.ops.aten.clamp.default:
             call_func = super().call_function(ttnn.clip, args, kwargs)
         elif target == torch.ops.aten.squeeze.dim:
-            call_func = super().call_function(ttnn.squeeze, args, kwargs)
+            # NOTE(kevinwuTT): ttnn.squeeze only supports dim 0 currently
+            if args[1] != 0:
+                call_func = super().call_function(target, args, kwargs)
+            else:
+                call_func = super().call_function(ttnn.squeeze, args, kwargs)
         elif target == torch.ops.aten.lt.Tensor:
             call_func =  super().call_function(ttnn.lt, args, kwargs)
         elif target == torch.ops.aten.cos.default:

--- a/torch_ttnn/passes/to_tt_pass.py
+++ b/torch_ttnn/passes/to_tt_pass.py
@@ -29,6 +29,13 @@ class ReplaceMoreTt(torch.fx.Transformer):
             # TODO(kevinwuMCW): include beta, alpha, and optional args
             mm = super().call_function(ttnn.matmul, (args[1], args[2]), kwargs)
             return super().call_function(ttnn.add, (args[0], mm), kwargs)
+        elif target == torch.ops.aten.div.Tensor:
+            recip = super().call_function(ttnn.reciprocal, (args[1],), kwargs)
+            return super().call_function(ttnn.mul, (args[0], recip), kwargs)
+        elif target == torch.ops.aten.bmm.default:
+            return super().call_function(ttnn.matmul, args, kwargs)
+        elif target == torch.ops.aten.gelu.default:
+            return super().call_function(ttnn.gelu, args, kwargs)
         return super().call_function(target, args, kwargs)
 
 

--- a/torch_ttnn/passes/to_tt_pass.py
+++ b/torch_ttnn/passes/to_tt_pass.py
@@ -1,4 +1,10 @@
 import torch
+from ..utils import (
+    GraphCleanup,
+    DummyTtlTensorTensorMemoryLayoutInterleaved,
+    DummyTtlTensorBufferTypeDram,
+    DummyTtnnBfloat16,
+)
 
 try:
     import ttnn
@@ -7,43 +13,77 @@ except ImportError:
     from .. import mock_ttnn as ttnn
 
 from torch.fx.passes.infra.pass_base import PassBase, PassResult
-
+import torch.fx.traceback as fx_traceback
 
 class ReplaceMoreTt(torch.fx.Transformer):
     def call_function(self, target, args, kwargs):
         if target == torch.ops.aten.sub.Tensor:
-            return super().call_function(ttnn.sub, args, kwargs)
+            call_func = super().call_function(ttnn.sub, args, kwargs)
         elif target == torch.ops.aten.rsub.Tensor:
             # TODO(kevinwuMCW): handle alpha parameter if exists
-            return super().call_function(ttnn.sub, (args[1], args[0]), kwargs)
+            call_func =  super().call_function(ttnn.sub, (args[1], args[0]), kwargs)
         elif target == torch.ops.aten.mul.Tensor:
-            return super().call_function(ttnn.mul, args, kwargs)
+            call_func =  super().call_function(ttnn.mul, args, kwargs)
         elif target == torch.ops.aten._softmax.default:
-            return super().call_function(ttnn.softmax, args[:2], kwargs)
+            call_func =  super().call_function(ttnn.softmax, args[:2], kwargs)
         elif target == torch.ops.aten.tanh.default:
-            return super().call_function(ttnn.tanh, args, kwargs)
+            call_func =  super().call_function(ttnn.tanh, args, kwargs)
         elif target == torch.ops.aten.view.default:
-            return super().call_function(ttnn.reshape, args, kwargs)
+            call_func =  super().call_function(ttnn.reshape, args, kwargs)
         elif target == torch.ops.aten.permute.default:
-            return super().call_function(ttnn.permute, args, kwargs)
+            call_func =  super().call_function(ttnn.permute, args, kwargs)
         elif target == torch.ops.aten.relu.default:
-            return super().call_function(ttnn.relu, args, kwargs)
+            call_func =  super().call_function(ttnn.relu, args, kwargs)
         elif target == torch.ops.aten.addmm.default:
             # TODO(kevinwuMCW): include beta, alpha, and optional args
             mm = super().call_function(ttnn.matmul, (args[1], args[2]), kwargs)
-            return super().call_function(ttnn.add, (args[0], mm), kwargs)
+            call_func =  super().call_function(ttnn.add, (args[0], mm), kwargs)
         elif target == torch.ops.aten.div.Tensor:
             recip = super().call_function(ttnn.reciprocal, (args[1],), kwargs)
-            return super().call_function(ttnn.mul, (args[0], recip), kwargs)
+            call_func =  super().call_function(ttnn.mul, (args[0], recip), kwargs)
         elif target == torch.ops.aten.bmm.default:
-            return super().call_function(ttnn.matmul, args, kwargs)
+            call_func =  super().call_function(ttnn.matmul, args, kwargs)
         elif target == torch.ops.aten.gelu.default:
-            return super().call_function(ttnn.gelu, args, kwargs)
+            call_func =  super().call_function(ttnn.gelu, args, kwargs)
         elif target == torch.ops.aten.embedding.default:
-            return super().call_function(ttnn.embedding, (args[1], args[0]), kwargs)
+            call_func =  super().call_function(ttnn.embedding, (args[1], args[0]), kwargs)
         elif target == torch.ops.aten.split.Tensor:
-            return super().call_function(ttnn.split, args, kwargs)
-        return super().call_function(target, args, kwargs)
+            call_func =  super().call_function(ttnn.split, args, kwargs)
+        else:
+            call_func = super().call_function(target, args, kwargs)
+
+        # Copy metadata of old node to replacement
+        meta = fx_traceback.get_current_meta()
+        if meta is not None and "val" in meta:
+            call_func.node.meta['val'] = meta["val"]
+        return call_func
+
+def torch_dtype_to_dummy_ttnn_dtype(dtype: torch.dtype):
+    # Add newly supported dtypes here:
+    dtype_map = {
+        torch.bfloat16 : DummyTtnnBfloat16()
+    }
+    if dtype in dtype_map:
+        return dtype_map.get(dtype)
+    else:
+        raise RuntimeError(f"Missing conversion from torch.dtype: {dtype} to DummyTtnn dtype.")
+
+def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
+    nodes = list(gm.graph.nodes)
+    for node in nodes:
+        g = node.graph
+        args = node.args
+        with g.inserting_before(node):
+            if node.target == torch.ops.aten.clone.default:
+                arg_metadata = node.meta["val"]
+                dummy_dtype = torch_dtype_to_dummy_ttnn_dtype(arg_metadata.dtype)
+                # Add additional logic to choose the appropriate memory_config type: DRAM or L1
+                memory_config = g.call_function(ttnn.MemoryConfig, (DummyTtlTensorTensorMemoryLayoutInterleaved(), DummyTtlTensorBufferTypeDram()))
+                new_node = g.call_function(ttnn.clone, args=(args[0], memory_config, dummy_dtype))
+                node.replace_all_uses_with(new_node, delete_user_cb=lambda node: node != new_node,)
+    
+    gm = GraphCleanup(gm)
+    return gm
 
 
 class ToTtPass(PassBase):
@@ -70,5 +110,8 @@ class ToTtPass(PassBase):
 
         # Replace more patterns with torch.fx.Transformer
         gm = ReplaceMoreTt(gm).transform()
+
+        # Replace patterns manually
+        gm = ReplaceMoreTtManually(gm)
 
         return PassResult(gm, True)

--- a/torch_ttnn/passes/to_tt_pass.py
+++ b/torch_ttnn/passes/to_tt_pass.py
@@ -28,11 +28,14 @@ int_output_ops = [
     torch.ops.aten.argmax.default,
     torch.ops.aten.argmin.default,
 ]
+
+
 def are_args_from_int_output_ops(args):
     for arg in args:
         if isinstance(arg, torch.fx.proxy.Proxy):
             if arg.node.target in int_output_ops:
                 return True
+
 
 class ReplaceMoreTt(torch.fx.Transformer):
     def call_function(self, target, args, kwargs):
@@ -42,38 +45,38 @@ class ReplaceMoreTt(torch.fx.Transformer):
             call_func = super().call_function(ttnn.sub, args, kwargs)
         elif target == torch.ops.aten.rsub.Tensor:
             # TODO(kevinwuMCW): handle alpha parameter if exists
-            call_func =  super().call_function(ttnn.sub, (args[1], args[0]), kwargs)
+            call_func = super().call_function(ttnn.sub, (args[1], args[0]), kwargs)
         elif target == torch.ops.aten.mul.Tensor:
-            call_func =  super().call_function(ttnn.mul, args, kwargs)
+            call_func = super().call_function(ttnn.mul, args, kwargs)
         elif target == torch.ops.aten._softmax.default:
-            call_func =  super().call_function(ttnn.softmax, args[:2], kwargs)
+            call_func = super().call_function(ttnn.softmax, args[:2], kwargs)
         elif target == torch.ops.aten.tanh.default:
-            call_func =  super().call_function(ttnn.tanh, args, kwargs)
+            call_func = super().call_function(ttnn.tanh, args, kwargs)
         elif target == torch.ops.aten.view.default:
             # TODO(kevinwuTT): Handle restrictions from ttnn.reshape
             call_func = super().call_function(target, args, kwargs)
         elif target == torch.ops.aten.permute.default:
-            call_func =  super().call_function(ttnn.permute, args, kwargs)
+            call_func = super().call_function(ttnn.permute, args, kwargs)
         elif target == torch.ops.aten.relu.default:
-            call_func =  super().call_function(ttnn.relu, args, kwargs)
+            call_func = super().call_function(ttnn.relu, args, kwargs)
         elif target == torch.ops.aten.addmm.default:
             # TODO(kevinwuMCW): include beta, alpha, and optional args
             mm = super().call_function(ttnn.matmul, (args[1], args[2]), kwargs)
-            call_func =  super().call_function(ttnn.add, (args[0], mm), kwargs)
+            call_func = super().call_function(ttnn.add, (args[0], mm), kwargs)
         elif target == torch.ops.aten.bmm.default:
-            call_func =  super().call_function(ttnn.matmul, args, kwargs)
+            call_func = super().call_function(ttnn.matmul, args, kwargs)
         elif target == torch.ops.aten.gelu.default:
-            call_func =  super().call_function(ttnn.gelu, args, kwargs)
+            call_func = super().call_function(ttnn.gelu, args, kwargs)
         elif target == torch.ops.aten.neg.default:
-            call_func =  super().call_function(ttnn.neg, args, kwargs)
+            call_func = super().call_function(ttnn.neg, args, kwargs)
         elif target == torch.ops.aten.tril.default:
-            call_func =  super().call_function(ttnn.tril, args, kwargs)
+            call_func = super().call_function(ttnn.tril, args, kwargs)
         elif target == torch.ops.aten.eq.Tensor:
-            call_func =  super().call_function(ttnn.eq, args, kwargs)
+            call_func = super().call_function(ttnn.eq, args, kwargs)
         elif target == torch.ops.aten.logical_not.default:
-            call_func =  super().call_function(ttnn.logical_not, args, kwargs)
+            call_func = super().call_function(ttnn.logical_not, args, kwargs)
         elif target == torch.ops.aten.zeros_like.default:
-            call_func =  super().call_function(ttnn.zeros_like, args, {})
+            call_func = super().call_function(ttnn.zeros_like, args, {})
         elif target == torch.ops.aten.mean.dim:
             # change dim parameter to tuple
             new_args = list(args)
@@ -91,7 +94,9 @@ class ReplaceMoreTt(torch.fx.Transformer):
             call_func = super().call_function(ttnn.silu, args, kwargs)
         elif target == torch.ops.aten._adaptive_avg_pool2d.default:
             # assumes output size is (1, 1)
-            call_func = super().call_function(ttnn.global_avg_pool2d, (args[0],), kwargs)
+            call_func = super().call_function(
+                ttnn.global_avg_pool2d, (args[0],), kwargs
+            )
         elif target == torch.ops.aten.clamp.default:
             call_func = super().call_function(ttnn.clip, args, kwargs)
         elif target == torch.ops.aten.squeeze.dim:
@@ -101,30 +106,34 @@ class ReplaceMoreTt(torch.fx.Transformer):
             else:
                 call_func = super().call_function(ttnn.squeeze, args, kwargs)
         elif target == torch.ops.aten.lt.Tensor:
-            call_func =  super().call_function(ttnn.lt, args, kwargs)
+            call_func = super().call_function(ttnn.lt, args, kwargs)
         elif target == torch.ops.aten.cos.default:
-            call_func =  super().call_function(ttnn.cos, args, kwargs)
+            call_func = super().call_function(ttnn.cos, args, kwargs)
         elif target == torch.ops.aten.sigmoid.default:
-            call_func =  super().call_function(ttnn.sigmoid, args, kwargs)
+            call_func = super().call_function(ttnn.sigmoid, args, kwargs)
         else:
             call_func = super().call_function(target, args, kwargs)
 
         # Copy metadata of old node to replacement
         meta = fx_traceback.get_current_meta()
         if meta is not None and "val" in meta:
-            call_func.node.meta['val'] = meta["val"]
+            call_func.node.meta["val"] = meta["val"]
         return call_func
+
 
 def torch_dtype_to_dummy_ttnn_dtype(dtype: torch.dtype):
     # Add newly supported dtypes here:
     dtype_map = {
-        torch.float32 : DummyTtnnBfloat16(),
-        torch.bfloat16 : DummyTtnnBfloat16()
+        torch.float32: DummyTtnnBfloat16(),
+        torch.bfloat16: DummyTtnnBfloat16(),
     }
     if dtype in dtype_map:
         return dtype_map.get(dtype)
     else:
-        raise RuntimeError(f"Missing conversion from torch.dtype: {dtype} to DummyTtnn dtype.")
+        raise RuntimeError(
+            f"Missing conversion from torch.dtype: {dtype} to DummyTtnn dtype."
+        )
+
 
 # Certain ops don't support certain shapes and will emit a valid_page_size error
 # RuntimeError: TT_FATAL @ ../tt_metal/impl/buffers/buffer.cpp:38: valid_page_size
@@ -134,6 +143,7 @@ def has_valid_page_size(shape):
         if dim < 32:
             return False
     return True
+
 
 def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
     nodes = list(gm.graph.nodes)
@@ -147,18 +157,41 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                 arg_metadata = node.meta["val"]
                 dummy_dtype = torch_dtype_to_dummy_ttnn_dtype(arg_metadata.dtype)
                 # Add additional logic to choose the appropriate memory_config type: DRAM or L1
-                memory_config = g.call_function(ttnn.MemoryConfig, (DummyTtlTensorTensorMemoryLayoutInterleaved(), DummyTtlTensorBufferTypeDram()))
-                new_node = g.call_function(ttnn.clone, args=(args[0], memory_config, dummy_dtype))
-                node.replace_all_uses_with(new_node, delete_user_cb=lambda node: node != new_node,)
+                memory_config = g.call_function(
+                    ttnn.MemoryConfig,
+                    (
+                        DummyTtlTensorTensorMemoryLayoutInterleaved(),
+                        DummyTtlTensorBufferTypeDram(),
+                    ),
+                )
+                new_node = g.call_function(
+                    ttnn.clone, args=(args[0], memory_config, dummy_dtype)
+                )
+                node.replace_all_uses_with(
+                    new_node,
+                    delete_user_cb=lambda node: node != new_node,
+                )
             if node.target == torch.ops.aten.native_layer_norm.default:
-                new_node = g.call_function(ttnn.layer_norm, args=(args[0],), kwargs={"epsilon": args[4], "weight": args[2], "bias": args[3]})
-                node.replace_all_uses_with(new_node, delete_user_cb=lambda node: node != new_node,)
+                new_node = g.call_function(
+                    ttnn.layer_norm,
+                    args=(args[0],),
+                    kwargs={"epsilon": args[4], "weight": args[2], "bias": args[3]},
+                )
+                node.replace_all_uses_with(
+                    new_node,
+                    delete_user_cb=lambda node: node != new_node,
+                )
                 node_users = list(new_node.users.keys())
                 for node_user in node_users:
                     node_user.replace_all_uses_with(new_node)
             if node.target == torch.ops.aten.ones.default:
-                new_node = g.call_function(ttnn.ones, args=args, kwargs={"device": DummyDevice()})
-                node.replace_all_uses_with(new_node, delete_user_cb=lambda node: node != new_node,)
+                new_node = g.call_function(
+                    ttnn.ones, args=args, kwargs={"device": DummyDevice()}
+                )
+                node.replace_all_uses_with(
+                    new_node,
+                    delete_user_cb=lambda node: node != new_node,
+                )
             """
             # NOTE(kevinwuTT): aten.arange.default starts with 0 which is unsupported by ttnn.arange at the moment
             if node.target == torch.ops.aten.arange.default:
@@ -174,49 +207,97 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                     # step = 1
                     new_args = (args[0],)
                     new_kwargs = {"end": args[1], "step": 1, "device": DummyDevice()}
-                    new_node = g.call_function(ttnn.arange, args=new_args, kwargs=new_kwargs)
-                    node.replace_all_uses_with(new_node, delete_user_cb=lambda node: node != new_node,)
+                    new_node = g.call_function(
+                        ttnn.arange, args=new_args, kwargs=new_kwargs
+                    )
+                    node.replace_all_uses_with(
+                        new_node,
+                        delete_user_cb=lambda node: node != new_node,
+                    )
             if node.target == torch.ops.aten.arange.start_step:
                 # NOTE(kevinwuTT): ttnn.arange does not support starting values smaller than 2 currently
                 if args[0] >= 2:
                     new_args = (args[0],)
-                    new_kwargs = {"end": args[1], "step": args[2], "device": DummyDevice()}
-                    new_node = g.call_function(ttnn.arange, args=new_args, kwargs=new_kwargs)
-                    node.replace_all_uses_with(new_node, delete_user_cb=lambda node: node != new_node,)
+                    new_kwargs = {
+                        "end": args[1],
+                        "step": args[2],
+                        "device": DummyDevice(),
+                    }
+                    new_node = g.call_function(
+                        ttnn.arange, args=new_args, kwargs=new_kwargs
+                    )
+                    node.replace_all_uses_with(
+                        new_node,
+                        delete_user_cb=lambda node: node != new_node,
+                    )
             if node.target in relational_scalar_ops:
                 # NOTE(kevinwuTT): ttnn.eq shows error if passing a literal scalar as an argument.
                 # Instead, fill a tensor with the same size as args[0] with the scalar value using ttnn.full
                 arg_metadata = node.meta["val"]
                 if has_valid_page_size(arg_metadata.size()):
-                    new_kwargs = {"fill_value": args[1], "device": DummyDevice(), "layout": DummyTtnnTileLayout()}
-                    full_node = g.call_function(ttnn.full, args=(arg_metadata.size(), ), kwargs=new_kwargs)
-                    new_node = g.call_function(relational_scalar_ops[node.target], args=(args[0], full_node), kwargs={})
-                    node.replace_all_uses_with(new_node, delete_user_cb=lambda node: node != new_node,)
+                    new_kwargs = {
+                        "fill_value": args[1],
+                        "device": DummyDevice(),
+                        "layout": DummyTtnnTileLayout(),
+                    }
+                    full_node = g.call_function(
+                        ttnn.full, args=(arg_metadata.size(),), kwargs=new_kwargs
+                    )
+                    new_node = g.call_function(
+                        relational_scalar_ops[node.target],
+                        args=(args[0], full_node),
+                        kwargs={},
+                    )
+                    node.replace_all_uses_with(
+                        new_node,
+                        delete_user_cb=lambda node: node != new_node,
+                    )
             if node.target == torch.ops.aten.full.default:
                 # args[0] can be empty for aten.full which simply creates a scalar. Ignore conversion in this case.
                 if args[0]:
-                    new_kwargs = {"fill_value": args[1], "device": DummyDevice(), "layout": DummyTtnnTileLayout()}
-                    new_node = g.call_function(ttnn.full, args=(tuple(args[0]), ), kwargs=new_kwargs)
-                    node.replace_all_uses_with(new_node, delete_user_cb=lambda node: node != new_node,)
+                    new_kwargs = {
+                        "fill_value": args[1],
+                        "device": DummyDevice(),
+                        "layout": DummyTtnnTileLayout(),
+                    }
+                    new_node = g.call_function(
+                        ttnn.full, args=(tuple(args[0]),), kwargs=new_kwargs
+                    )
+                    node.replace_all_uses_with(
+                        new_node,
+                        delete_user_cb=lambda node: node != new_node,
+                    )
             if node.target == torch.ops.aten.baddbmm.default:
                 kwargs = node.kwargs
                 # out = beta * input + alpha * (batch1 @ batch2)
                 # if beta is 0, input is ignored, and nan and inf in it will not be propogated
                 new_node = g.call_function(ttnn.matmul, args=(args[1], args[2]))
                 if "alpha" in kwargs:
-                    new_node = g.call_function(ttnn.multiply, args=(new_node, kwargs["alpha"]))
+                    new_node = g.call_function(
+                        ttnn.multiply, args=(new_node, kwargs["alpha"])
+                    )
                 if "beta" in kwargs:
                     if kwargs["beta"] != 0:
-                        beta_node = g.call_function(ttnn.multiply, args=(args[0], kwargs["beta"]))
+                        beta_node = g.call_function(
+                            ttnn.multiply, args=(args[0], kwargs["beta"])
+                        )
                         new_node = g.call_function(ttnn.add, args=(beta_node, new_node))
                 else:
                     new_node = g.call_function(ttnn.add, args=(args[0], new_node))
-                node.replace_all_uses_with(new_node, delete_user_cb=lambda node: node != new_node,)
+                node.replace_all_uses_with(
+                    new_node,
+                    delete_user_cb=lambda node: node != new_node,
+                )
             if node.target == torch.ops.aten.embedding.default:
                 # TODO(kevinwuTT): Add support for ROW_MAJOR_LAYOUT
                 new_kwargs = {"layout": DummyTtnnTileLayout()}
-                new_node =  g.call_function(ttnn.embedding, args=(args[1], args[0]), kwargs=new_kwargs)
-                node.replace_all_uses_with(new_node, delete_user_cb=lambda node: node != new_node,)
+                new_node = g.call_function(
+                    ttnn.embedding, args=(args[1], args[0]), kwargs=new_kwargs
+                )
+                node.replace_all_uses_with(
+                    new_node,
+                    delete_user_cb=lambda node: node != new_node,
+                )
             if node.target == torch.ops.aten.rsub.Scalar:
                 # NOTE(kevinwuTT): ttnn.sub shows error if passing a literal scalar as the first argument.
                 # Instead, fill a tensor with the same size as args[0] with the scalar value using aten.full
@@ -224,20 +305,34 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                 # NOTE(kevinwuTT): Only bfloat16 seems to work for now
                 # TODO(kevinwuTT): Use ttnn.full instead of aten
                 new_kwargs = {"dtype": torch.bfloat16}
-                full_node = g.call_function(torch.ops.aten.full.default, args=(arg_metadata.size(), args[1]), kwargs=new_kwargs)
-                new_node = g.call_function(ttnn.sub, args=(full_node, args[0]), kwargs={})
-                node.replace_all_uses_with(new_node, delete_user_cb=lambda node: node != new_node,)
+                full_node = g.call_function(
+                    torch.ops.aten.full.default,
+                    args=(arg_metadata.size(), args[1]),
+                    kwargs=new_kwargs,
+                )
+                new_node = g.call_function(
+                    ttnn.sub, args=(full_node, args[0]), kwargs={}
+                )
+                node.replace_all_uses_with(
+                    new_node,
+                    delete_user_cb=lambda node: node != new_node,
+                )
             if node.target == torch.ops.aten.div.Tensor:
                 # ttnn.recip does not support scalars. Call an aten.full and pass that to ttnn.recip
                 # TODO(kevinwuTT): Use a ttnn equivalent
                 node_metadata = node.meta["val"]
                 if isinstance(args[1], float):
-                    full = g.call_function(torch.ops.aten.full.default, (node_metadata.size(), args[1]), {})
+                    full = g.call_function(
+                        torch.ops.aten.full.default, (node_metadata.size(), args[1]), {}
+                    )
                     recip = g.call_function(ttnn.reciprocal, (full,), {})
                 else:
                     recip = g.call_function(ttnn.reciprocal, (args[1],), {})
                 new_node = g.call_function(ttnn.mul, (args[0], recip), {})
-                node.replace_all_uses_with(new_node, delete_user_cb=lambda node: node != new_node,)
+                node.replace_all_uses_with(
+                    new_node,
+                    delete_user_cb=lambda node: node != new_node,
+                )
 
     gm = GraphCleanup(gm)
     return gm

--- a/torch_ttnn/passes/to_tt_pass.py
+++ b/torch_ttnn/passes/to_tt_pass.py
@@ -13,6 +13,9 @@ class ReplaceMoreTt(torch.fx.Transformer):
     def call_function(self, target, args, kwargs):
         if target == torch.ops.aten.sub.Tensor:
             return super().call_function(ttnn.sub, args, kwargs)
+        if target == torch.ops.aten.rsub.Tensor:
+            # TODO(kevinwuMCW): handle alpha parameter if exists
+            return super().call_function(ttnn.sub, (args[1], args[0]), kwargs)
         elif target == torch.ops.aten.mul.Tensor:
             return super().call_function(ttnn.mul, args, kwargs)
         elif target == torch.ops.aten._softmax.default:
@@ -36,6 +39,8 @@ class ReplaceMoreTt(torch.fx.Transformer):
             return super().call_function(ttnn.matmul, args, kwargs)
         elif target == torch.ops.aten.gelu.default:
             return super().call_function(ttnn.gelu, args, kwargs)
+        elif target == torch.ops.aten.embedding.default:
+            return super().call_function(ttnn.embedding, (args[1], args[0]), kwargs)
         return super().call_function(target, args, kwargs)
 
 

--- a/torch_ttnn/passes/to_tt_pass.py
+++ b/torch_ttnn/passes/to_tt_pass.py
@@ -322,8 +322,11 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                 # TODO(kevinwuTT): Use a ttnn equivalent
                 node_metadata = node.meta["val"]
                 if isinstance(args[1], float):
+                    new_kwargs = {"dtype": torch.bfloat16}
                     full = g.call_function(
-                        torch.ops.aten.full.default, (node_metadata.size(), args[1]), {}
+                        torch.ops.aten.full.default,
+                        (node_metadata.size(), args[1]),
+                        new_kwargs,
                     )
                     recip = g.call_function(ttnn.reciprocal, (full,), {})
                 else:

--- a/torch_ttnn/passes/to_tt_pass.py
+++ b/torch_ttnn/passes/to_tt_pass.py
@@ -89,6 +89,8 @@ class ReplaceMoreTt(torch.fx.Transformer):
             call_func = super().call_function(ttnn.squeeze, args, kwargs)
         elif target == torch.ops.aten.lt.Tensor:
             call_func =  super().call_function(ttnn.lt, args, kwargs)
+        elif target == torch.ops.aten.cos.default:
+            call_func =  super().call_function(ttnn.cos, args, kwargs)
         else:
             call_func = super().call_function(target, args, kwargs)
 

--- a/torch_ttnn/passes/to_tt_pass.py
+++ b/torch_ttnn/passes/to_tt_pass.py
@@ -54,8 +54,6 @@ class ReplaceMoreTt(torch.fx.Transformer):
             call_func =  super().call_function(ttnn.gelu, args, kwargs)
         elif target == torch.ops.aten.embedding.default:
             call_func =  super().call_function(ttnn.embedding, (args[1], args[0]), kwargs)
-        elif target == torch.ops.aten.split.Tensor:
-            call_func =  super().call_function(ttnn.split, args, kwargs)
         elif target == torch.ops.aten.neg.default:
             call_func =  super().call_function(ttnn.neg, args, kwargs)
         elif target == torch.ops.aten.tril.default:

--- a/torch_ttnn/passes/to_tt_pass.py
+++ b/torch_ttnn/passes/to_tt_pass.py
@@ -23,6 +23,12 @@ class ReplaceMoreTt(torch.fx.Transformer):
             return super().call_function(ttnn.reshape, args, kwargs)
         elif target == torch.ops.aten.permute.default:
             return super().call_function(ttnn.permute, args, kwargs)
+        elif target == torch.ops.aten.relu.default:
+            return super().call_function(ttnn.relu, args, kwargs)
+        elif target == torch.ops.aten.addmm.default:
+            # TODO(kevinwuMCW): include beta, alpha, and optional args
+            mm = super().call_function(ttnn.matmul, (args[1], args[2]), kwargs)
+            return super().call_function(ttnn.add, (args[0], mm), kwargs)
         return super().call_function(target, args, kwargs)
 
 

--- a/torch_ttnn/passes/to_tt_pass.py
+++ b/torch_ttnn/passes/to_tt_pass.py
@@ -13,7 +13,7 @@ class ReplaceMoreTt(torch.fx.Transformer):
     def call_function(self, target, args, kwargs):
         if target == torch.ops.aten.sub.Tensor:
             return super().call_function(ttnn.sub, args, kwargs)
-        if target == torch.ops.aten.rsub.Tensor:
+        elif target == torch.ops.aten.rsub.Tensor:
             # TODO(kevinwuMCW): handle alpha parameter if exists
             return super().call_function(ttnn.sub, (args[1], args[0]), kwargs)
         elif target == torch.ops.aten.mul.Tensor:

--- a/torch_ttnn/passes/to_tt_pass.py
+++ b/torch_ttnn/passes/to_tt_pass.py
@@ -71,6 +71,19 @@ class ReplaceMoreTt(torch.fx.Transformer):
             call_func = super().call_function(ttnn.add, args, kwargs)
         elif target == torch.ops.aten.mm.default:
             call_func = super().call_function(ttnn.matmul, args, kwargs)
+        elif target == torch.ops.aten.pow.Tensor_Scalar:
+            call_func = super().call_function(ttnn.pow, args, kwargs)
+        elif target == torch.ops.aten.rsqrt.default:
+            call_func = super().call_function(ttnn.rsqrt, args, kwargs)
+        elif target == torch.ops.aten.silu.default:
+            call_func = super().call_function(ttnn.silu, args, kwargs)
+        elif target == torch.ops.aten._adaptive_avg_pool2d.default:
+            # assumes output size is (1, 1)
+            call_func = super().call_function(ttnn.global_avg_pool2d, (args[0],), kwargs)
+        elif target == torch.ops.aten.clamp.default:
+            call_func = super().call_function(ttnn.clip, args, kwargs)
+        elif target == torch.ops.aten.squeeze.dim:
+            call_func = super().call_function(ttnn.squeeze, args, kwargs)
         else:
             call_func = super().call_function(target, args, kwargs)
 

--- a/torch_ttnn/passes/to_tt_pass.py
+++ b/torch_ttnn/passes/to_tt_pass.py
@@ -35,7 +35,8 @@ class ReplaceMoreTt(torch.fx.Transformer):
         elif target == torch.ops.aten.tanh.default:
             call_func =  super().call_function(ttnn.tanh, args, kwargs)
         elif target == torch.ops.aten.view.default:
-            call_func =  super().call_function(ttnn.reshape, args, kwargs)
+            # TODO(kevinwuTT): Handle restrictions from ttnn.reshape
+            call_func = super().call_function(target, args, kwargs)
         elif target == torch.ops.aten.permute.default:
             call_func =  super().call_function(ttnn.permute, args, kwargs)
         elif target == torch.ops.aten.relu.default:

--- a/torch_ttnn/patterns/add.py
+++ b/torch_ttnn/patterns/add.py
@@ -1,3 +1,6 @@
+# TODO(kevinwuTT): I have a patch for tt-metal that assigns the __name__ attribute of each Operation.
+# This file may not be needed anymore.
+
 import torch
 
 try:

--- a/torch_ttnn/patterns/mm.py
+++ b/torch_ttnn/patterns/mm.py
@@ -1,3 +1,6 @@
+# TODO(kevinwuTT): I have a patch for tt-metal that assigns the __name__ attribute of each Operation.
+# This file may not be needed anymore.
+
 import torch
 
 try:

--- a/torch_ttnn/torch_stat.py
+++ b/torch_ttnn/torch_stat.py
@@ -73,7 +73,7 @@ class TorchStatOption:
         out=os.path.join(os.getcwd(), "stat"),
         gen_graphviz=False,
     ):
-        self.model_name = model_name
+        self.model_name = model_name.replace("/", "_")
         self.backward = backward
         self.out = out
         self.gen_graphviz = gen_graphviz

--- a/torch_ttnn/torch_stat.py
+++ b/torch_ttnn/torch_stat.py
@@ -38,6 +38,7 @@ def aten_backend(
         "raw",
         f"{direction}_{option.model_name}_{option.counter['val']}.json",
     )
+    print(stat_filename)
     os.makedirs(os.path.dirname(stat_filename), exist_ok=True)
     passes = [StatPass(filename=stat_filename, example_inputs=example_inputs)]
     if option.gen_graphviz:
@@ -91,5 +92,6 @@ def backend(torch_stat_option: TorchStatOption):
         )
     else:
         return aot_autograd(
-            fw_compiler=partial(aten_backend, options=options, direction="fw")
+            fw_compiler=partial(aten_backend, options=options, direction="fw"),
+            # inference_compiler=partial(aten_backend, options=options, direction="fw"),
         )

--- a/torch_ttnn/torch_stat.py
+++ b/torch_ttnn/torch_stat.py
@@ -4,6 +4,7 @@ from typing import List
 import torch._dynamo
 import os
 from collections import Counter
+from functorch.compile import make_boxed_func
 
 torch._dynamo.config.suppress_errors = False
 torch._dynamo.config.verbose = True
@@ -56,7 +57,7 @@ def aten_backend(
     gm.recompile()
     option.out_fx_graphs.append(gm.graph)
     option.counter["val"] += 1
-    return gm
+    return make_boxed_func(gm)
 
 
 from torch._dynamo.backends.common import aot_autograd

--- a/torch_ttnn/utils.py
+++ b/torch_ttnn/utils.py
@@ -27,3 +27,11 @@ class DummyTtnnUint32:
 class DummyTtnnBfloat16:
     def __repr__(self):
         return f"ttnn_bfloat16"
+
+class DummyTtlTensorTensorMemoryLayoutInterleaved:
+    def __repr__(self):
+        return f"ttl_tensor_TensorMemoryLayout_INTERLEAVED"
+
+class DummyTtlTensorBufferTypeDram:
+    def __repr__(self):
+        return f"ttl_tensor_BufferType_DRAM"

--- a/torch_ttnn/utils.py
+++ b/torch_ttnn/utils.py
@@ -1,0 +1,9 @@
+import torch
+
+def GraphCleanup(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
+    gm.graph.eliminate_dead_code()
+    gm.graph.lint()
+    gm.recompile()
+
+    return gm
+

--- a/torch_ttnn/utils.py
+++ b/torch_ttnn/utils.py
@@ -1,4 +1,79 @@
 import torch
+import numpy as np
+
+# Testing utils copied from tt-metal/tests/ttnn/utils_for_testing.py
+def comp_pcc(golden, calculated, pcc=0.99):
+    golden = torch.Tensor(golden)
+    calculated = torch.Tensor(calculated)
+
+    if golden.dtype != calculated.dtype:
+        calculated = calculated.type(golden.dtype)
+
+    if torch.all(torch.isnan(golden)) and torch.all(torch.isnan(calculated)):
+        # logger.warning("Both tensors are 'nan'")
+        return True, 1.0
+
+    if torch.all(torch.isnan(golden)) or torch.all(torch.isnan(calculated)):
+        # logger.error("One tensor is all nan, the other is not.")
+        return False, 0.0
+
+    # Test if either is completely zero
+    if torch.any(golden.bool()) != torch.any(calculated.bool()):
+        # logger.error("One tensor is all zero")
+        return False, 0.0
+
+    # For now, mask all infs and nans so that we check the rest... TODO
+    golden = golden.clone()
+    golden[
+        torch.logical_or(
+            torch.isnan(golden),
+            torch.logical_or(torch.isinf(golden), torch.isneginf(golden)),
+        )
+    ] = 0
+    calculated = calculated.clone()
+    calculated[
+        torch.logical_or(
+            torch.isnan(calculated),
+            torch.logical_or(torch.isinf(calculated), torch.isneginf(calculated)),
+        )
+    ] = 0
+
+    if torch.equal(golden, calculated):
+        return True, 1.0
+
+    if golden.dtype == torch.bfloat16:
+        golden = golden.type(torch.float32)
+        calculated = calculated.type(torch.float32)
+    cal_pcc = np.min(
+        np.ma.corrcoef(
+            np.ma.masked_invalid(torch.squeeze(golden).detach().numpy()).flatten(),
+            np.ma.masked_invalid(torch.squeeze(calculated).detach().numpy()).flatten(),
+        )
+    )
+
+    if isinstance(cal_pcc, np.ma.core.MaskedConstant):
+        return True, 1.0
+
+    return cal_pcc >= pcc, cal_pcc
+
+def construct_pcc_assert_message(message, expected_pytorch_result, actual_pytorch_result):
+    messages = []
+    messages.append(message)
+    # messages.append("Expected")
+    # messages.append(str(expected_pytorch_result))
+    # messages.append("Actual")
+    # messages.append(str(actual_pytorch_result))
+    messages = [str(m) for m in messages]
+    return "\n".join(messages)
+
+def check_with_pcc(expected_pytorch_result, actual_pytorch_result, pcc=0.9999):
+    if expected_pytorch_result.shape != actual_pytorch_result.shape:
+        return (
+            False,
+            f"list(expected_pytorch_result.shape)={list(expected_pytorch_result.shape)} vs list(actual_pytorch_result.shape)={list(actual_pytorch_result.shape)}",
+        )
+    pcc_passed, pcc_message = comp_pcc(expected_pytorch_result, actual_pytorch_result, pcc)
+    return pcc_passed, construct_pcc_assert_message(pcc_message, expected_pytorch_result, actual_pytorch_result)
 
 def GraphCleanup(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
     gm.graph.eliminate_dead_code()

--- a/torch_ttnn/utils.py
+++ b/torch_ttnn/utils.py
@@ -1,6 +1,7 @@
 import torch
 import numpy as np
 
+
 # Testing utils copied from tt-metal/tests/ttnn/utils_for_testing.py
 def comp_pcc(golden, calculated, pcc=0.99):
     golden = torch.Tensor(golden)
@@ -56,7 +57,10 @@ def comp_pcc(golden, calculated, pcc=0.99):
 
     return cal_pcc >= pcc, cal_pcc
 
-def construct_pcc_assert_message(message, expected_pytorch_result, actual_pytorch_result):
+
+def construct_pcc_assert_message(
+    message, expected_pytorch_result, actual_pytorch_result
+):
     messages = []
     messages.append(message)
     # messages.append("Expected")
@@ -66,14 +70,20 @@ def construct_pcc_assert_message(message, expected_pytorch_result, actual_pytorc
     messages = [str(m) for m in messages]
     return "\n".join(messages)
 
+
 def check_with_pcc(expected_pytorch_result, actual_pytorch_result, pcc=0.9999):
     if expected_pytorch_result.shape != actual_pytorch_result.shape:
         return (
             False,
             f"list(expected_pytorch_result.shape)={list(expected_pytorch_result.shape)} vs list(actual_pytorch_result.shape)={list(actual_pytorch_result.shape)}",
         )
-    pcc_passed, pcc_message = comp_pcc(expected_pytorch_result, actual_pytorch_result, pcc)
-    return pcc_passed, construct_pcc_assert_message(pcc_message, expected_pytorch_result, actual_pytorch_result)
+    pcc_passed, pcc_message = comp_pcc(
+        expected_pytorch_result, actual_pytorch_result, pcc
+    )
+    return pcc_passed, construct_pcc_assert_message(
+        pcc_message, expected_pytorch_result, actual_pytorch_result
+    )
+
 
 def GraphCleanup(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
     gm.graph.eliminate_dead_code()
@@ -82,30 +92,37 @@ def GraphCleanup(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
 
     return gm
 
+
 # See https://docs.google.com/document/d/1r2D4AagoeTRjEmXFnWzzafaWQkf-8hlIbX2ze-JAUFo/edit#heading=h.zad9rwqjv6cr
 class DummyDevice:
     def __repr__(self):
         return f"ttnn_Specified_Device"
 
+
 class DummyTtnnRowMajorLayout:
     def __repr__(self):
         return f"ttnn_ROW_MAJOR_LAYOUT"
+
 
 class DummyTtnnTileLayout:
     def __repr__(self):
         return f"ttnn_TILE_LAYOUT"
 
+
 class DummyTtnnUint32:
     def __repr__(self):
         return f"ttnn_uint32"
+
 
 class DummyTtnnBfloat16:
     def __repr__(self):
         return f"ttnn_bfloat16"
 
+
 class DummyTtlTensorTensorMemoryLayoutInterleaved:
     def __repr__(self):
         return f"ttl_tensor_TensorMemoryLayout_INTERLEAVED"
+
 
 class DummyTtlTensorBufferTypeDram:
     def __repr__(self):

--- a/torch_ttnn/utils.py
+++ b/torch_ttnn/utils.py
@@ -7,3 +7,23 @@ def GraphCleanup(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
 
     return gm
 
+# See https://docs.google.com/document/d/1r2D4AagoeTRjEmXFnWzzafaWQkf-8hlIbX2ze-JAUFo/edit#heading=h.zad9rwqjv6cr
+class DummyDevice:
+    def __repr__(self):
+        return f"ttnn_Specified_Device"
+
+class DummyTtnnRowMajorLayout:
+    def __repr__(self):
+        return f"ttnn_ROW_MAJOR_LAYOUT"
+
+class DummyTtnnTileLayout:
+    def __repr__(self):
+        return f"ttnn_TILE_LAYOUT"
+
+class DummyTtnnUint32:
+    def __repr__(self):
+        return f"ttnn_uint32"
+
+class DummyTtnnBfloat16:
+    def __repr__(self):
+        return f"ttnn_bfloat16"


### PR DESCRIPTION
### Ticket
#10 

### Problem description
Trace the aten ops used by chosen LLM models and implement conversions to ttnn. Initial goal to run a "bert" model e2e with no or minimum fallback ops as possible.

### What's changed
- Add basic conversion for ops used by LLM models
  - op usage: https://docs.google.com/spreadsheets/d/1fJuorhiQJo2ra5N_9Rv2zUNK2ZPSEOgycZ8YqhLocvk/edit?usp=sharing
  - each conversion is accompanied by a unit test
- Fixes to match changes from tt-metal upstream
- Add demo for a couple of huggingface transformer models