### PR TITLE
Enable run of integration tests like resnet

### DIFF
--- a/.github/workflows/before_merge.yaml
+++ b/.github/workflows/before_merge.yaml
@@ -33,6 +33,7 @@ jobs:
         env:
           pytest_verbosity: 2
           pytest_report_title: "⭐️ Pytest Results ⭐️"
+          RUN_INTEGRATION_TESTS: 1
         run: | 
           source venv/bin/activate
           python3 -m pytest --github-report tests/*.py

--- a/tests/test_real_world.py
+++ b/tests/test_real_world.py
@@ -16,9 +16,6 @@ class TestRealWorld(unittest.TestCase):
         # Close the device
         ttnn.close_device(self.device)
 
-    @unittest.skip(
-        "Skip this test because it take 135 MB to download the ResNet18 model. Un-skip it if you want to test it."
-    )
     @unittest.skipUnless(
         os.getenv("RUN_INTEGRATION_TESTS", "0") == "1",
         "Skip this test because it takes 135 MB to download the ResNet18 model. Set RUN_INTEGRATION_TESTS=1 to run it.",

--- a/tests/test_real_world.py
+++ b/tests/test_real_world.py
@@ -4,6 +4,7 @@ import torch_ttnn
 import unittest
 from torch_ttnn import ttnn
 import collections
+import os
 
 
 class TestRealWorld(unittest.TestCase):
@@ -17,6 +18,10 @@ class TestRealWorld(unittest.TestCase):
 
     @unittest.skip(
         "Skip this test because it take 135 MB to download the ResNet18 model. Un-skip it if you want to test it."
+    )
+    @unittest.skipUnless(
+        os.getenv("RUN_INTEGRATION_TESTS", "0") == "1",
+        "Skip this test because it takes 135 MB to download the ResNet18 model. Set RUN_INTEGRATION_TESTS=1 to run it.",
     )
     def test_resnet(self):
         # Download model from cloud


### PR DESCRIPTION
### Ticket
None

### Problem description
We have an integration test for resnet, but it is currently marked as skip to avoid downloading extra

### What's changed
Introduce an environment variable support `RUN_INTEGRATION_TESTS`. When it is set to 1 test will run.
