### PR TITLE
Implement conversion for aten.expand by using ttnn.repeat

### DIFF
--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -1,0 +1,183 @@
+import torch
+import torch_ttnn
+import unittest
+from torch_ttnn import ttnn
+import tt_lib
+from torch_ttnn.utils import (
+    DummyTtnnRowMajorLayout,
+    DummyTtnnTileLayout,
+)
+
+
+class ExpandModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x, new_shape):
+        return x.expand(new_shape)
+
+    def input_shapes(self):
+        return [(1, 4), (4, 4)]
+
+
+class ExpandAfterOpModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x, new_shape):
+        a = torch.clone(x)
+        return a.expand(new_shape)
+
+    def input_shapes(self):
+        return [(1, 4), (4, 4)]
+
+
+class ExpandBeforeOpModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x, new_shape):
+        ex = x.expand(new_shape)
+        return torch.add(ex, ex)
+
+    def input_shapes(self):
+        return [(1, 4), (4, 4)]
+
+
+class ExpandBetweenOpsModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x, new_shape):
+        a = torch.clone(x)
+        ex = a.expand(new_shape)
+        return torch.add(ex, ex)
+
+    def input_shapes(self):
+        return [(1, 4), (4, 4)]
+
+
+class TestModules(unittest.TestCase):
+    def setUp(self):
+        # Open device 0
+        self.device: ttnn.Device = ttnn.open_device(device_id=0)
+        # For AutoFormat
+        tt_lib.device.SetDefaultDevice(self.device)
+
+    def tearDown(self):
+        # Close the device
+        ttnn.close_device(self.device)
+
+    def test_expand(self):
+        m = ExpandModule()
+        input_shapes = m.input_shapes()
+        tensor = torch.rand(input_shapes[0], dtype=torch.bfloat16)
+        new_shape = input_shapes[1]
+        inputs = [tensor, new_shape]
+        result_before = m.forward(*inputs)
+        option = torch_ttnn.TorchTtnnOption(device=self.device)
+        option.gen_graphviz = True
+        # The compilation is lazy, so we need to run forward once to trigger the compilation
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+        result_after = m.forward(*inputs)
+        option._out_fx_graphs[0].print_tabular()
+
+        # Check the graph has be rewritten and contain ttnn ops
+        nodes = list(option._out_fx_graphs[0].nodes)
+        self.assertTrue(nodes[4].target == ttnn.repeat)
+        self.assertTrue(nodes[4].args[1].target == ttnn.Shape)
+        self.assertTrue(nodes[5].target == ttnn.from_device)
+        self.assertTrue(nodes[6].target == ttnn.to_layout)
+        self.assertTrue(nodes[7].target == ttnn.to_torch)
+        # Check inference result
+        self.assertTrue(torch.allclose(result_before, result_after, rtol=0.2))
+
+    def test_expand_after_op(self):
+        m = ExpandAfterOpModule()
+        input_shapes = m.input_shapes()
+        tensor = torch.rand(input_shapes[0], dtype=torch.bfloat16)
+        new_shape = input_shapes[1]
+        inputs = [tensor, new_shape]
+        result_before = m.forward(*inputs)
+        option = torch_ttnn.TorchTtnnOption(device=self.device)
+        option.gen_graphviz = True
+        # The compilation is lazy, so we need to run forward once to trigger the compilation
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+        result_after = m.forward(*inputs)
+        option._out_fx_graphs[0].print_tabular()
+
+        # Check the graph has be rewritten and contain ttnn ops
+        nodes = list(option._out_fx_graphs[0].nodes)
+        self.assertTrue(nodes[8].target == ttnn.repeat)
+        self.assertTrue(nodes[8].args[0].target == ttnn.to_layout)
+        self.assertTrue(nodes[8].args[0].args[0].target == ttnn.clone)
+        self.assertTrue(
+            type(nodes[8].args[0].args[1]) is type(DummyTtnnRowMajorLayout())
+        )
+        self.assertTrue(nodes[8].args[1].target == ttnn.Shape)
+        self.assertTrue(nodes[9].target == ttnn.from_device)
+        self.assertTrue(nodes[10].target == ttnn.to_layout)
+        self.assertTrue(nodes[11].target == ttnn.to_torch)
+        # Check inference result
+        self.assertTrue(torch.allclose(result_before, result_after, rtol=0.2))
+
+    def test_expand_before_op(self):
+        m = ExpandBeforeOpModule()
+        input_shapes = m.input_shapes()
+        tensor = torch.rand(input_shapes[0], dtype=torch.bfloat16)
+        new_shape = input_shapes[1]
+        inputs = [tensor, new_shape]
+        result_before = m.forward(*inputs)
+        option = torch_ttnn.TorchTtnnOption(device=self.device)
+        option.gen_graphviz = True
+        # The compilation is lazy, so we need to run forward once to trigger the compilation
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+        result_after = m.forward(*inputs)
+        option._out_fx_graphs[0].print_tabular()
+
+        # Check the graph has be rewritten and contain ttnn ops
+        nodes = list(option._out_fx_graphs[0].nodes)
+        self.assertTrue(nodes[4].target == ttnn.repeat)
+        self.assertTrue(nodes[4].args[1].target == ttnn.Shape)
+        self.assertTrue(nodes[5].target == ttnn.to_layout)
+        self.assertTrue(nodes[5].args[0].target == ttnn.repeat)
+        self.assertTrue(type(nodes[5].args[1]) is type(DummyTtnnTileLayout()))
+        self.assertTrue(nodes[6].target == ttnn.add)
+        self.assertTrue(nodes[7].target == ttnn.from_device)
+        self.assertTrue(nodes[8].target == ttnn.to_layout)
+        self.assertTrue(nodes[9].target == ttnn.to_torch)
+        # Check inference result
+        self.assertTrue(torch.allclose(result_before, result_after, rtol=0.2))
+
+    def test_expand_between_ops(self):
+        m = ExpandBetweenOpsModule()
+        input_shapes = m.input_shapes()
+        tensor = torch.rand(input_shapes[0], dtype=torch.bfloat16)
+        new_shape = input_shapes[1]
+        inputs = [tensor, new_shape]
+        result_before = m.forward(*inputs)
+        option = torch_ttnn.TorchTtnnOption(device=self.device)
+        option.gen_graphviz = True
+        # The compilation is lazy, so we need to run forward once to trigger the compilation
+        m = torch.compile(m, backend=torch_ttnn.backend, options=option)
+        result_after = m.forward(*inputs)
+        option._out_fx_graphs[0].print_tabular()
+
+        # Check the graph has be rewritten and contain ttnn ops
+        nodes = list(option._out_fx_graphs[0].nodes)
+        self.assertTrue(nodes[8].target == ttnn.repeat)
+        self.assertTrue(nodes[8].args[0].target == ttnn.to_layout)
+        self.assertTrue(nodes[8].args[0].args[0].target == ttnn.clone)
+        self.assertTrue(
+            type(nodes[8].args[0].args[1]) is type(DummyTtnnRowMajorLayout())
+        )
+        self.assertTrue(nodes[8].args[1].target == ttnn.Shape)
+        self.assertTrue(nodes[9].target == ttnn.to_layout)
+        self.assertTrue(nodes[9].args[0].target == ttnn.repeat)
+        self.assertTrue(type(nodes[9].args[1]) is type(DummyTtnnTileLayout()))
+        self.assertTrue(nodes[10].target == ttnn.add)
+        self.assertTrue(nodes[11].target == ttnn.from_device)
+        self.assertTrue(nodes[12].target == ttnn.to_layout)
+        self.assertTrue(nodes[13].target == ttnn.to_torch)
+        # Check inference result
+        self.assertTrue(torch.allclose(result_before, result_after, rtol=0.2))

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -181,3 +181,7 @@ class TestModules(unittest.TestCase):
         self.assertTrue(nodes[13].target == ttnn.to_torch)
         # Check inference result
         self.assertTrue(torch.allclose(result_before, result_after, rtol=0.2))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/torch_ttnn/passes/add_data_move_pass.py
+++ b/torch_ttnn/passes/add_data_move_pass.py
@@ -67,6 +67,7 @@ def is_tt_compute(node) -> bool:
             ttnn.cos,
             ttnn.sigmoid,
             ttnn.as_tensor,
+            ttnn.repeat,
         ]
     )
 
@@ -81,6 +82,7 @@ def is_tt_data_move(node) -> bool:
         ttnn.to_torch,
         ttnn.to_layout,
         ttnn.MemoryConfig,
+        ttnn.Shape,
     ]
 
 
@@ -173,6 +175,7 @@ def try_add_data_move_in(src_node, dst_idx, dst_node, device) -> torch.fx.node.N
             dst_node.target != ttnn.reshape
             and dst_node.target != ttnn.embedding
             and dst_node.target != ttnn.zeros_like
+            and dst_node.target != ttnn.repeat
         ):
             new_nodes.append(
                 g.call_function(ttnn.to_layout, (new_nodes[-1], DummyTtnnTileLayout()))
@@ -185,6 +188,48 @@ def try_add_data_move_in(src_node, dst_idx, dst_node, device) -> torch.fx.node.N
 
     insert_node_between(src_node, dst_idx, dst_node, new_nodes)
     return new_nodes[-1]
+
+
+def try_add_layout_change_before_repeat(
+    src_node, dst_idx, dst_node
+) -> torch.fx.node.Node:
+    # Consider dst_node is ttnn.repeat, and src_node are any tt nodes that ttnn.repeat uses
+    if isinstance(src_node, (int, float, list, tuple)) or not isinstance(
+        src_node, torch.fx.node.Node
+    ):
+        return None
+    if not is_function_call(dst_node):
+        return None
+    if dst_node.target != ttnn.repeat or dst_idx != 0 or not is_tt(src_node):
+        return None
+
+    g = dst_node.graph
+    with g.inserting_before(dst_node):
+        to_layout = g.call_function(
+            ttnn.to_layout, (src_node, DummyTtnnRowMajorLayout())
+        )
+
+    insert_node_between(src_node, dst_idx, dst_node, [to_layout])
+
+    return to_layout
+
+
+def try_add_layout_change_after_repeat(
+    src_node, dst_idx, dst_node
+) -> torch.fx.node.Node:
+    # Consider src_node is ttnn.repeat, and dst_node should be any tt_compute node that uses ttnn.repeat
+    if not is_function_call(src_node):
+        return None
+    if src_node.target != ttnn.repeat or not is_tt_compute(dst_node):
+        return None
+
+    g = dst_node.graph
+    with g.inserting_before(dst_node):
+        to_layout = g.call_function(ttnn.to_layout, (dst_node, DummyTtnnTileLayout()))
+
+    insert_node_between(src_node, dst_idx, dst_node, [to_layout])
+
+    return to_layout
 
 
 def try_add_data_move_out(src_node, dst_idx, dst_node) -> torch.fx.node.Node:
@@ -277,6 +322,12 @@ class AddDataMovePass(PassBase):
                     node.update_arg(idx, data_move_in_hash[arg])
                 elif to_device := try_add_data_move_in(arg, idx, node, device):
                     data_move_in_hash[arg] = to_device
+                    i += 1
+                elif to_layout := try_add_layout_change_before_repeat(arg, idx, node):
+                    data_move_in_hash[arg] = to_layout
+                    i += 1
+                elif to_layout := try_add_layout_change_after_repeat(arg, idx, node):
+                    data_move_in_hash[arg] = to_layout
                     i += 1
 
                 if arg in data_move_out_hash and node.op == "output":

--- a/torch_ttnn/passes/to_tt_pass.py
+++ b/torch_ttnn/passes/to_tt_pass.py
@@ -7,6 +7,7 @@ from ..utils import (
     DummyDevice,
     DummyTtnnTileLayout,
 )
+import numpy as np
 
 try:
     import ttnn
@@ -167,6 +168,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                 new_node = g.call_function(
                     ttnn.clone, args=(args[0], memory_config, dummy_dtype)
                 )
+                new_node.meta["val"] = node.meta["val"]
                 node.replace_all_uses_with(
                     new_node,
                     delete_user_cb=lambda node: node != new_node,
@@ -177,9 +179,9 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                     args=(args[0],),
                     kwargs={"epsilon": args[4], "weight": args[2], "bias": args[3]},
                 )
+                new_node.meta["val"] = node.meta["val"]
                 node.replace_all_uses_with(
-                    new_node,
-                    delete_user_cb=lambda node: node != new_node,
+                    new_node, delete_user_cb=lambda node: node != new_node
                 )
                 node_users = list(new_node.users.keys())
                 for node_user in node_users:
@@ -188,6 +190,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                 new_node = g.call_function(
                     ttnn.ones, args=args, kwargs={"device": DummyDevice()}
                 )
+                new_node.meta["val"] = node.meta["val"]
                 node.replace_all_uses_with(
                     new_node,
                     delete_user_cb=lambda node: node != new_node,
@@ -210,6 +213,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                     new_node = g.call_function(
                         ttnn.arange, args=new_args, kwargs=new_kwargs
                     )
+                    new_node.meta["val"] = node.meta["val"]
                     node.replace_all_uses_with(
                         new_node,
                         delete_user_cb=lambda node: node != new_node,
@@ -226,6 +230,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                     new_node = g.call_function(
                         ttnn.arange, args=new_args, kwargs=new_kwargs
                     )
+                    new_node.meta["val"] = node.meta["val"]
                     node.replace_all_uses_with(
                         new_node,
                         delete_user_cb=lambda node: node != new_node,
@@ -248,6 +253,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                         args=(args[0], full_node),
                         kwargs={},
                     )
+                    new_node.meta["val"] = node.meta["val"]
                     node.replace_all_uses_with(
                         new_node,
                         delete_user_cb=lambda node: node != new_node,
@@ -263,6 +269,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                     new_node = g.call_function(
                         ttnn.full, args=(tuple(args[0]),), kwargs=new_kwargs
                     )
+                    new_node.meta["val"] = node.meta["val"]
                     node.replace_all_uses_with(
                         new_node,
                         delete_user_cb=lambda node: node != new_node,
@@ -284,6 +291,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                         new_node = g.call_function(ttnn.add, args=(beta_node, new_node))
                 else:
                     new_node = g.call_function(ttnn.add, args=(args[0], new_node))
+                new_node.meta["val"] = node.meta["val"]
                 node.replace_all_uses_with(
                     new_node,
                     delete_user_cb=lambda node: node != new_node,
@@ -294,6 +302,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                 new_node = g.call_function(
                     ttnn.embedding, args=(args[1], args[0]), kwargs=new_kwargs
                 )
+                new_node.meta["val"] = node.meta["val"]
                 node.replace_all_uses_with(
                     new_node,
                     delete_user_cb=lambda node: node != new_node,
@@ -317,6 +326,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                 new_node = g.call_function(
                     ttnn.sub, args=(to_layout, args[0]), kwargs={}
                 )
+                new_node.meta["val"] = node.meta["val"]
                 node.replace_all_uses_with(
                     new_node,
                     delete_user_cb=lambda node: node != new_node,
@@ -342,6 +352,7 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                 else:
                     recip = g.call_function(ttnn.reciprocal, (args[1],), {})
                 new_node = g.call_function(ttnn.mul, (args[0], recip), {})
+                new_node.meta["val"] = node.meta["val"]
                 node.replace_all_uses_with(
                     new_node,
                     delete_user_cb=lambda node: node != new_node,
@@ -364,9 +375,25 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
                     "memory_config": memory_config,
                 }
                 new_node = g.call_function(ttnn.as_tensor, args, new_kwargs)
+                new_node.meta["val"] = node.meta["val"]
                 node.replace_all_uses_with(
                     new_node,
                     delete_user_cb=lambda node: node != new_node,
+                )
+            if node.target == torch.ops.aten.expand.default:
+                # aten.expand and ttnn.repeat has different meaning for their `shape` argument
+                # aten.expand: the desired output shape, where respective singleton dims are broadcasted
+                # ttnn.repeat: the number of times to repeat a respective singleton dim
+                input_tensor_shape = args[0].meta["val"].size()
+                output_shape = torch.Size(args[1])
+
+                multiplier = np.array(output_shape) // np.array(input_tensor_shape)
+
+                shape_node = g.call_function(ttnn.Shape, (multiplier.tolist(),), {})
+                new_node = g.call_function(ttnn.repeat, (args[0], shape_node), {})
+                new_node.meta["val"] = node.meta["val"]
+                node.replace_all_uses_with(
+                    new_node, delete_user_cb=lambda node: node != new_node
                 )
 
     gm = GraphCleanup(gm)
@@ -375,8 +402,22 @@ def ReplaceMoreTtManually(gm: torch.fx.GraphModule) -> torch.fx.GraphModule:
 
 class ToTtPass(PassBase):
     def call(self, gm: torch.fx.GraphModule):
+        # TODO(kevinwuTT): transform() removes metadata from Placeholder (input argument) nodes.
+        # Reversing the order will not work either because of the already converted ttnn.ops under
+        # ReplaceMoreTtManually. Might need to consider consolidating these methods.
+
+        # Save Placeholder metadata before calling transform()
+        input_nodes = {
+            node.name: node.meta for node in gm.graph.nodes if node.op == "placeholder"
+        }
+
         # Replace more patterns with torch.fx.Transformer
         gm = ReplaceMoreTt(gm).transform()
+
+        # Restore metadata for Placeholder nodes
+        for node in gm.graph.nodes:
+            if node.op == "placeholder":
+                node.meta = input_nodes[node.name]
 
         # Replace patterns manually
         gm = ReplaceMoreTtManually(gm)


### PR DESCRIPTION
### Problem description
Transform aten.expand by using ttnn.repeat. 

### What's changed
The interpretation of the `shape` argument between the two ops differ. For aten.expand the `shape` argument is the desired output shape. For ttnn.repeat the `shape` argument is a multiplier of the input shape instead. Therefore the shape information of the input tensor is needed.
* Add retention of shape metadata information for Placeholder nodes since transform() removes them
  * Add missing metadata for conversions done under ReplaceMoreTtManually
* Implement the conversion from aten.expand using the shape metadata
 
In addition, ttnn.repeat acts differently between TILE and ROW_MAJOR layouts. In most cases, we would need to change the layout of a node to ROW_MAJOR before passing that to ttnn.repeat. Similarly, we would need to check if a layout change back to TILE is needed if any following node that uses ttnn.repeat is a tt compute node.
* Add logic to insert layout changes before and/or after ttnn.repeat
