### PR TITLE
Add metrics collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ stat
 *.dot
 *.svg
 *.csv
+metrics

--- a/tests/lowering/tensor_manipulation/test_aten_t.py
+++ b/tests/lowering/tensor_manipulation/test_aten_t.py
@@ -4,7 +4,7 @@ import unittest
 import ttnn
 import tt_lib
 
-from torch_ttnn.utils import check_with_pcc
+from tests.utils import check_with_pcc
 
 
 class AtenTModule(torch.nn.Module):

--- a/tests/models/bert/test_bert.py
+++ b/tests/models/bert/test_bert.py
@@ -5,10 +5,7 @@ import ttnn
 from torch_ttnn.utils import RunTimeMetrics
 
 # Load model directly
-from transformers import (
-    AutoTokenizer,
-    AutoModelForQuestionAnswering,
-)
+from transformers import AutoTokenizer, AutoModelForQuestionAnswering
 
 
 class TestBert(unittest.TestCase):
@@ -45,9 +42,12 @@ class TestBert(unittest.TestCase):
             truncation=True,
         )
 
+        metrics_path = "BERT"
         # Run inference with the original model
         with torch.no_grad():
-            outputs_before = RunTimeMetrics("BERT", "original", lambda: m(**inputs))
+            outputs_before = RunTimeMetrics(
+                metrics_path, "original", lambda: m(**inputs)
+            )
 
         # Helper function to decode output to human-readable text
         def decode_output(outputs):
@@ -59,13 +59,17 @@ class TestBert(unittest.TestCase):
         answer_before = decode_output(outputs_before)
 
         # Compile model with ttnn backend
-        option = torch_ttnn.TorchTtnnOption(device=self.device, metrics_path="BERT")
+        option = torch_ttnn.TorchTtnnOption(
+            device=self.device, metrics_path=metrics_path
+        )
         m = torch.compile(m, backend=torch_ttnn.backend, options=option)
 
         # Run inference with the compiled model
         with torch.no_grad():
-            outputs_after = RunTimeMetrics("BERT", "compiled", lambda: m(**inputs))
-        # option._out_fx_graphs[0].print_tabular()
+            outputs_after = RunTimeMetrics(
+                metrics_path, "compiled", lambda: m(**inputs)
+            )
+        option._out_fx_graphs[0].print_tabular()
 
         answer_after = decode_output(outputs_after)
 

--- a/tests/models/resnet/test_resnet.py
+++ b/tests/models/resnet/test_resnet.py
@@ -4,7 +4,8 @@ import torch_ttnn
 import unittest
 import ttnn
 import collections
-from torch_ttnn.utils import check_with_pcc, RunTimeMetrics
+from torch_ttnn.utils import RunTimeMetrics
+from tests.utils import check_with_pcc
 
 
 class TestRestNet(unittest.TestCase):

--- a/tests/models/resnet/test_resnet.py
+++ b/tests/models/resnet/test_resnet.py
@@ -25,22 +25,26 @@ class TestRestNet(unittest.TestCase):
         # Create random input tensor
         input_batch = torch.rand((1, 3, 224, 224), dtype=torch.bfloat16)
 
+        metrics_path = "ResNet18"
         # Run inference with the original model
         with torch.no_grad():
             output_before = RunTimeMetrics(
-                "ResNet18", "original", lambda: model(input_batch)
+                metrics_path, "original", lambda: model(input_batch)
             )
 
         # Compile the model
-        option = torch_ttnn.TorchTtnnOption(device=self.device, metrics_path="ResNet18")
+        option = torch_ttnn.TorchTtnnOption(
+            device=self.device, metrics_path=metrics_path
+        )
         option.gen_graphviz = True
         model = torch.compile(model, backend=torch_ttnn.backend, options=option)
 
         # Run inference with the compiled model
         with torch.no_grad():
             output_after = RunTimeMetrics(
-                "ResNet18", "compiled", lambda: model(input_batch)
+                metrics_path, "compiled", lambda: model(input_batch)
             )
+        option._out_fx_graphs[0].print_tabular()
 
         # TODO: Check the graph has be rewritten and contain ttnn ops
 

--- a/tools/collect_metrics.py
+++ b/tools/collect_metrics.py
@@ -1,0 +1,150 @@
+import torch
+import os
+import pickle
+import csv
+from pathlib import Path
+
+from torch_ttnn.utils import comp_pcc
+
+
+def load_pickle(path: str):
+    with open(path, "rb") as f:
+        return pickle.load(f)
+
+
+# Map dictionary keys from metrics to header descriptions
+csv_header_mappings = {
+    "model": "Model",
+    "success": "Run Success",
+    "torch_ops_before": "Torch Ops (Before)",
+    "torch_ops_remain": "Torch Ops (Remain)",
+    "to_from_device_ops": "To/From_Device Ops",
+    "original_run_time": "Original Run Time (s)",
+    "compiled_run_time": "Compiled Run Time(s)",
+    "accuracy": "Accuracy",
+}
+
+if __name__ == "__main__":
+    # Holds the concatenation of all the metrics for each model
+    all_metrics = []
+
+    # Assumed directory structure example. Some files will not exist if test failed.
+    """
+    pytorch2.0_ttnn
+    ├── metrics
+        ├── BERT
+        │   ├── compiled-op_metrics.pickle
+        │   ├── compiled-outputs.pt
+        │   ├── compiled-runtime_metrics.pickle
+        │   ├── original-outputs.pt
+        │   └── original-runtime_metrics.pickle
+        └── ResNet18
+            ├── compiled-runtime_metrics.pickle
+            └── original-runtime_metrics.pickle
+    """
+    for model in os.listdir("metrics"):
+        model_path = Path("metrics") / Path(model)
+
+        # read pickle files
+        original_runtime_metrics_path = model_path / "original-runtime_metrics.pickle"
+        compiled_runtime_metrics_path = model_path / "compiled-runtime_metrics.pickle"
+        # Both runtime files should exist
+        assert os.path.isfile(
+            original_runtime_metrics_path
+        ), f"{original_runtime_metrics_path} file not found"
+        assert os.path.isfile(
+            compiled_runtime_metrics_path
+        ), f"{compiled_runtime_metrics_path} file not found"
+        original_runtime_metrics = load_pickle(original_runtime_metrics_path)
+        compiled_runtime_metrics = load_pickle(compiled_runtime_metrics_path)
+
+        # Rename run_time keys to match original or compiled
+        if "run_time" in original_runtime_metrics:
+            original_runtime_metrics["original_run_time"] = (
+                original_runtime_metrics.pop("run_time")
+            )
+        if "run_time" in compiled_runtime_metrics:
+            compiled_runtime_metrics["compiled_run_time"] = (
+                compiled_runtime_metrics.pop("run_time")
+            )
+
+        # Metric containing op counts. Will not exist if test failed.
+        compiled_ops_metrics_path = model_path / "compiled-op_metrics.pickle"
+        compiled_ops_metrics = (
+            load_pickle(compiled_ops_metrics_path)
+            if os.path.isfile(compiled_ops_metrics_path)
+            else {}
+        )
+
+        # Read outputs and compute accuracy. Will not exist if test failed.
+        # Some models have multiple outputs. Collect them all and compute the average pcc.
+        original_outputs_path = model_path / "original-outputs.pt"
+        compiled_outputs_path = model_path / "compiled-outputs.pt"
+
+        original_outputs = (
+            torch.load(original_outputs_path)
+            if os.path.isfile(original_outputs_path)
+            else {}
+        )
+        compiled_outputs = (
+            torch.load(compiled_outputs_path)
+            if os.path.isfile(compiled_outputs_path)
+            else {}
+        )
+
+        if isinstance(original_outputs, dict) and isinstance(compiled_outputs, dict):
+            # Handle case where outputs can be converted to dictionaries
+            if not original_outputs or not compiled_outputs:
+                accuracy = "N/A"
+            else:
+                original_outputs = dict(original_outputs)
+                compiled_outputs = dict(compiled_outputs)
+                output_pccs = []
+                for key in original_outputs.keys() & compiled_outputs.keys():
+                    _, pcc = comp_pcc(original_outputs[key], compiled_outputs[key])
+                    output_pccs.append(pcc)
+                accuracy = torch.mean(torch.tensor(output_pccs)).item()
+        elif isinstance(original_outputs, torch.Tensor) and isinstance(
+            compiled_outputs, torch.Tensor
+        ):
+            # Handle case where outputs are Pytorch Tensors
+            _, accuracy = comp_pcc(original_outputs, compiled_outputs)
+        else:
+            raise ValueError(
+                f"Output types not supported. Review these outputs:\n"
+                f"original_outputs:\n"
+                f"{original_outputs}\n"
+                f"compiled_outputs:\n"
+                f"{compiled_outputs}\n",
+            )
+        accuracy_metric = {"accuracy": accuracy}
+        model_metric = {"model": model}
+
+        # Concatenate all the metrics together
+        cat_metrics = {
+            **original_runtime_metrics,
+            **compiled_runtime_metrics,
+            **compiled_ops_metrics,
+            **accuracy_metric,
+            **model_metric,
+        }
+        # Remap original keys with header descriptions to prepare for exporting to csv
+        cat_metrics_remapped = {}
+        for key, val in csv_header_mappings.items():
+            if key in cat_metrics:
+                cat_metrics_remapped[val] = cat_metrics[key]
+            else:
+                cat_metrics_remapped[val] = "N/A"
+
+        all_metrics.append(cat_metrics_remapped)
+
+    # Write to csv
+    if all_metrics:
+        with open(f"metrics.csv", "w", newline="") as f:
+            w = csv.DictWriter(f, all_metrics[0].keys())
+            w.writeheader()
+            print(all_metrics[0].keys())
+            for row in all_metrics:
+                print(row)
+                w.writerow(row)
+            print(f"Data written to metrics.csv")

--- a/tools/collect_metrics.py
+++ b/tools/collect_metrics.py
@@ -60,13 +60,13 @@ if __name__ == "__main__":
 
         # Rename run_time keys to match original or compiled
         if "run_time" in original_runtime_metrics:
-            original_runtime_metrics["original_run_time"] = (
-                original_runtime_metrics.pop("run_time")
-            )
+            original_runtime_metrics[
+                "original_run_time"
+            ] = original_runtime_metrics.pop("run_time")
         if "run_time" in compiled_runtime_metrics:
-            compiled_runtime_metrics["compiled_run_time"] = (
-                compiled_runtime_metrics.pop("run_time")
-            )
+            compiled_runtime_metrics[
+                "compiled_run_time"
+            ] = compiled_runtime_metrics.pop("run_time")
 
         # Metric containing op counts. Will not exist if test failed.
         compiled_ops_metrics_path = model_path / "compiled-op_metrics.pickle"

--- a/tools/collect_metrics.py
+++ b/tools/collect_metrics.py
@@ -4,7 +4,7 @@ import pickle
 import csv
 from pathlib import Path
 
-from torch_ttnn.utils import comp_pcc
+from tests.utils import comp_pcc
 
 
 def load_pickle(path: str):

--- a/torch_ttnn/backend.py
+++ b/torch_ttnn/backend.py
@@ -4,6 +4,9 @@ from typing import List
 import torch._dynamo
 from functorch.compile import make_boxed_func
 import ttnn
+import pickle
+from pathlib import Path
+import os
 
 torch._dynamo.config.suppress_errors = False
 torch._dynamo.config.verbose = True
@@ -28,6 +31,22 @@ def aten_backend(
     gm = remove_clones_for_input_aliasing(gm)
 
     option: TorchTtnnOption = options["torch_ttnn_option"]
+
+    # Helper function to count the number of aten ops in the graph currently
+    def count_aten_ops():
+        aten_ops = [
+            str(node.target)
+            for node in list(gm.graph.nodes)
+            if node.op in ["call_function", "call_method"]
+            and isinstance(node.target, torch._ops.OpOverload)
+            and "aten" in str(node.target)
+        ]
+        return len(aten_ops)
+
+    # Save the number of aten ops before compilation
+    if option.metrics_path:
+        option._metrics["torch_ops_before"] = count_aten_ops()
+
     torch.fx.graph._register_custom_builtin("ttnn_Specified_Device", "", option.device)
     torch.fx.graph._register_custom_builtin(
         "ttnn_ROW_MAJOR_LAYOUT", "", ttnn.ROW_MAJOR_LAYOUT
@@ -92,8 +111,26 @@ def aten_backend(
 
     gm.graph.lint()
     gm.recompile()
-    gm.graph.print_tabular()
-    print(gm.code)
+
+    if option.metrics_path:
+        # Save the number of aten ops after compilation
+        option._metrics["torch_ops_remain"] = count_aten_ops()
+        # Save the number of to/from_device ops in current graph
+        to_from_device_ops = [
+            node.target.__name__
+            for node in list(gm.graph.nodes)
+            if node.op in ["call_function", "call_method"]
+            and (
+                "ttnn.to" in node.target.__name__ or "ttnn.from" in node.target.__name__
+            )
+        ]
+        option._metrics["to_from_device_ops"] = len(to_from_device_ops)
+        # Save the data as pickle files
+        p = Path(f"metrics/{option.metrics_path}")
+        pickle_out_path = p / "compiled-op_metrics.pickle"
+        with open(pickle_out_path, "wb") as f:
+            pickle.dump(option._metrics, f)
+
     option._out_fx_graphs.append(gm.graph)
     return make_boxed_func(gm)
 
@@ -104,10 +141,16 @@ from functools import partial
 
 # The option for torch_ttnn.backend
 class TorchTtnnOption:
-    def __init__(self, device: ttnn.Device):
+    def __init__(self, device: ttnn.Device, gen_graphviz=False, metrics_path=""):
         self.device = device
-        self.gen_graphviz = False
+        self.gen_graphviz = gen_graphviz
         self._out_fx_graphs = list()
+
+        if metrics_path:
+            p = Path(f"metrics/{metrics_path}")
+            os.makedirs(p, exist_ok=True)
+        self.metrics_path = metrics_path
+        self._metrics = dict()
 
 
 from .handle_input_aliasing import insert_clones_for_input_aliasing


### PR DESCRIPTION
### Problem description
Generate metrics that resembles the following example when running test models:
```
| Model   | Run Success | Torch Ops (Before)  | Torch Ops (Remains) | To/From_Device Ops | Original Run Time (s) | Compiled Run Time (s) | Accuracy          |
|---------|--------------|--------------------|---------------------|--------------------|-----------------------|-----------------------|-------------------|
| ResNet  | Yes          | 1234               | 567                 | 12                 | 0.45                  | 0.30                  | 85.5%             |
| VGG     | Yes          | 2345               | 890                 | 10                 | 0.50                  | 0.35                  | 92.1%             |
| BERT    | No           | 3456               | N/A                 | N/A                | N/A                   | N/A                   | N/A               |
```

### How to run
```
pytest tests/models
python3 tools/collect_metrics.py
```
`metrics.csv` will be generated in the base directory of the repo

Sample run on my Grayskull VM:
```
Model,Run Success,Torch Ops (Before),Torch Ops (Remain),To/From_Device Ops,Original Run Time (s),Compiled Run Time(s),Accuracy
ResNet18,Yes,70,43,132,1.7748399539850652,9.067756048985757,0.9999226429397775
BERT,Yes,1393,684,3862,61.74298016901594,38.48160677799024,0.9864120722326671
```

### What's changed
* Added util function that measures the runtime and status of a model. 
* Collect the count of torch ops before and after compilation.
* Collect the count of to/from_device ops after compilation.
* Create a helper script that parses the `metrics` directory for relevant files and generates a .csv that resembles the table above. The helper script also computes the accuracy between the original and compiled run by reading the relevant output files.
* Modify BERT and ResNet18 test models to request metrics collection
